### PR TITLE
feat: simple email password login

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,25 +1,9 @@
-# app.py
-# Streamlit login page (Supabase email OTP / magic link) — two-step with DB check
-
 import streamlit as st
-from f_auth import (
-    send_login_otp,
-    verify_otp,
-    set_session_from_query_params,
-    current_user,
-    sign_out,
-)
-from f_read import is_registered_email
+from f_auth import login, current_user, sign_out
 
 st.set_page_config(page_icon="📧", layout="centered")
 
 st.subheader("Pagos • Iniciar sesión")
-
-# Handle magic-link tokens if you ever use them
-if set_session_from_query_params():
-    st.session_state.pop("otp_sent", None)
-    st.session_state.pop("otp_email", None)
-    st.success("Sesión iniciada por enlace.")
 
 user = current_user()
 if user:
@@ -31,70 +15,12 @@ if user:
     st.success("¡Listo! Ya estás autenticado.")
     st.stop()
 
-# ---------- Not signed in: two-step ----------
-otp_sent = st.session_state.get("otp_sent", False)
-otp_email = st.session_state.get("otp_email", "")
-
-if not otp_sent:
-    st.write("Ingresa tu correo. Solo usuarios registrados pueden solicitar código.")
-    with st.form("email_form", clear_on_submit=False):
-        email = st.text_input("Email", placeholder="tu@empresa.com")
-        send_clicked = st.form_submit_button("Enviar código")
-        if send_clicked:
-            email_clean = (email or "").strip()
-            if not email_clean:
-                st.error("El email es obligatorio.")
-            elif not is_registered_email(email_clean):
-                st.error("Este correo no está registrado. Pide acceso al administrador.")
-            else:
-                try:
-                    send_login_otp(email_clean)
-                    st.session_state["otp_sent"] = True
-                    st.session_state["otp_email"] = email_clean
-                    st.success("Código enviado. Revisa tu correo.")
-                    st.rerun()
-                except Exception as e:
-                    st.error(f"Error enviando OTP: {e}")
-else:
-    st.write(f"Enviamos un código a **{otp_email}**.")
-    with st.form("otp_form", clear_on_submit=False):
-        code = st.text_input("Código de 6 dígitos", placeholder="123456")
-        colA, colB, colC = st.columns([1, 1, 1])
-        with colA:
-            verify_clicked = st.form_submit_button("Verificar código")
-        with colB:
-            resend_clicked = st.form_submit_button("Reenviar código")
-        with colC:
-            change_email_clicked = st.form_submit_button("Cambiar correo")
-
-        if verify_clicked:
-            if not (code and code.strip()):
-                st.error("Ingresa el código.")
-            else:
-                try:
-                    sess = verify_otp(otp_email, code.strip())
-                    if sess:
-                        st.success("¡Autenticado!")
-                        st.session_state.pop("otp_sent", None)
-                        st.session_state.pop("otp_email", None)
-                        st.rerun()
-                    else:
-                        st.error("No se pudo verificar el código.")
-                except Exception as e:
-                    st.error(f"Error verificando OTP: {e}")
-
-        if resend_clicked:
-            try:
-                # Re-check registration before resending (in case admin removed user)
-                if not is_registered_email(otp_email):
-                    st.error("Este correo ya no está registrado.")
-                else:
-                    send_login_otp(otp_email)
-                    st.info("Te reenviamos el código. Revisa tu correo.")
-            except Exception as e:
-                st.error(f"No se pudo reenviar el código: {e}")
-
-        if change_email_clicked:
-            st.session_state.pop("otp_sent", None)
-            st.session_state.pop("otp_email", None)
-            st.rerun()
+with st.form("login_form", clear_on_submit=False):
+    email = st.text_input("Email", placeholder="tu@empresa.com")
+    password = st.text_input("Contraseña", type="password")
+    submitted = st.form_submit_button("Entrar")
+    if submitted:
+        if login(email, password):
+            st.switch_page("pages/administrador.py")
+        else:
+            st.error("Wrong credentials")

--- a/f_cud.py
+++ b/f_cud.py
@@ -19,6 +19,15 @@ def delete_app_user(email: str) -> None:
     email_norm = (email or "").strip().lower()
     sb.schema("public").table("app_users").delete().eq("email", email_norm).execute()
 
+# ------------- Passwords -------------
+
+def update_user_password(email: str, new_password: str) -> None:
+    sb = get_client()
+    email_norm = (email or "").strip()
+    if not email_norm:
+        raise ValueError("Correo inválido.")
+    sb.schema("public").table("users").update({"password": new_password}).eq("email", email_norm).execute()
+
 # ------------- Roles (user_roles) -------------
 
 VALID_ROLES = {"administrador", "solicitante", "aprobador", "pagador", "lector"}

--- a/pages/administrador.py
+++ b/pages/administrador.py
@@ -7,7 +7,7 @@ import streamlit as st
 from supabase import create_client
 from f_auth import require_administrador, current_user, get_client
 from f_read import get_all_users, list_suppliers
-from f_cud import assign_role, remove_role, add_app_user, create_supplier
+from f_cud import assign_role, remove_role, add_app_user, create_supplier, update_user_password
 
 st.set_page_config(page_icon="🛡️", layout="wide")
 require_administrador()
@@ -32,7 +32,7 @@ def get_admin_client():
 
 ADMIN_CLIENT = get_admin_client()
 
-tab_crear, tab_editar, tab_prov = st.tabs(["Crear usuario", "Editar usuario", "Proveedores"])
+tab_crear, tab_editar, tab_pass, tab_prov = st.tabs(["Crear usuario", "Editar usuario", "Actualizar contraseña", "Proveedores"])
 
 # =======================
 # Tab 1: Crear usuario
@@ -177,7 +177,30 @@ with tab_editar:
                 st.error(f"Error al guardar cambios: {e}")
 
 # =======================
-# Tab 3: Proveedores
+# Tab 3: Actualizar contraseña
+# =======================
+with tab_pass:
+    users = get_all_users()
+    emails = [u["email"] for u in users]
+    if not emails:
+        st.info("Aún no hay usuarios.")
+    else:
+        with st.form("password_form", clear_on_submit=True):
+            email = st.selectbox("Selecciona un usuario", emails)
+            new_pwd = st.text_input("Nueva contraseña", type="password")
+            submitted = st.form_submit_button("Actualizar")
+            if submitted:
+                if not new_pwd:
+                    st.error("La contraseña no puede estar vacía.")
+                else:
+                    try:
+                        update_user_password(email, new_pwd)
+                        st.success("Contraseña actualizada.")
+                    except Exception as e:
+                        st.error(f"No se pudo actualizar: {e}")
+
+# =======================
+# Tab 4: Proveedores
 # =======================
 with tab_prov:
 


### PR DESCRIPTION
## Summary
- replace OTP flow with email/password login
- add login helper and password update utilities
- allow admins to update user passwords

## Testing
- `python -m py_compile app.py f_auth.py f_cud.py pages/administrador.py`


------
https://chatgpt.com/codex/tasks/task_e_68b61d386be4832eab7952b61197bd95