### PR TITLE
Add download link to expense documents in approver view

### DIFF
--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -133,7 +133,8 @@ with tab2:
 
     # ---- Left: details, logs, comments
     with left:
-        st.markdown(
+        rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
+        details_md = (
             f"**Proveedor:** {exp['supplier_name']}  \n"
             f"**Descripción:** {exp.get('description','')}  \n"
             f"**Monto:** {exp['amount']:.2f}  \n"
@@ -142,11 +143,11 @@ with tab2:
             f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
             f"**Solicitante:** {exp.get('requested_by_email','')}"
         )
-
-        rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
-        render_quote_preview_if_pdf(exp.get("supporting_doc_key") or "")
         if rec_url:
-            st.link_button("Ver documento de respaldo", rec_url, use_container_width=True)
+            details_md += f"  \n**Documento de respaldo:** [Descargar]({rec_url})"
+        st.markdown(details_md)
+
+        render_quote_preview_if_pdf(exp.get("supporting_doc_key") or "")
 
         st.divider()
         st.subheader("Historial (logs)")


### PR DESCRIPTION
## Summary
- Show a download link within the approver's detail view for the supporting document stored in `quotes`

## Testing
- `python -m py_compile pages/aprobador.py`


------
https://chatgpt.com/codex/tasks/task_e_68b71a1ff98c832ebd03763e9bc95f28