### PR TITLE
Avoid logging comment creation

### DIFF
--- a/f_cud.py
+++ b/f_cud.py
@@ -172,19 +172,16 @@ def create_expense(
     return expense_id
 
 def add_expense_comment(expense_id: str, actor_id: str, text: str) -> None:
-    """
-    Inserta un comentario en expense_logs usando action='update' y details.kind='comment'.
-    """
+    """Guarda un comentario para la solicitud sin generar un nuevo log."""
     if not (expense_id and actor_id and (text or "").strip()):
         raise ValueError("Faltan datos para comentar.")
     sb = get_client()
     payload = {
         "expense_id": expense_id,
         "actor_id": actor_id,
-        "action": "update",  # permitido por el CHECK del esquema
-        "details": {"kind": "comment", "text": text.strip()},
+        "text": text.strip(),
     }
-    sb.schema("public").table("expense_logs").insert(payload).execute()
+    sb.schema("public").table("expense_comments").insert(payload).execute()
 
 
 ## APROBADOR

--- a/f_read.py
+++ b/f_read.py
@@ -237,18 +237,13 @@ def list_expense_logs(expense_id: str) -> List[Dict[str, Any]]:
     return rows
 
 def list_expense_comments(expense_id: str) -> List[Dict[str, Any]]:
-    """
-    Comentarios = logs con action='update' y details.kind='comment'.
-    Devuelve [{created_at, text, actor_email}, ...]
-    """
+    """Devuelve comentarios [{created_at, text, actor_email}, ...]"""
     sb = get_client()
     res = (
         sb.schema("public")
-        .table("expense_logs")
-        .select("actor_id,action,details,created_at")
+        .table("expense_comments")
+        .select("actor_id,text,created_at")
         .eq("expense_id", expense_id)
-        .eq("action", "update")
-        .eq("details->>kind", "comment")   # filtra JSONB por clave 'kind'
         .order("created_at", desc=True)
         .execute()
     )
@@ -256,10 +251,9 @@ def list_expense_comments(expense_id: str) -> List[Dict[str, Any]]:
     emails = _emails_by_ids({r["actor_id"] for r in rows})
     out = []
     for r in rows:
-        det = r.get("details") or {}
         out.append({
             "created_at": r["created_at"],
-            "text": det.get("text", ""),
+            "text": r.get("text", ""),
             "actor_email": emails.get(r["actor_id"]),
         })
     return out


### PR DESCRIPTION
## Summary
- Store new expense comments in a dedicated `expense_comments` table rather than logging them
- Query comments from `expense_comments` without creating log entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71a9d4a64832ead10a20409ab646b