### PR TITLE
Format expense log details for readability

### DIFF
--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -160,7 +160,7 @@ with tab2:
                         "Fecha": _fmt_dt(lg["created_at"]),
                         "Acción": lg["action"],
                         "Actor": lg.get("actor_email", ""),
-                        "Detalles": lg.get("details", {}),
+                        "Detalles": lg.get("details_text", ""),
                     }
                     for lg in logs
                 ]
@@ -304,7 +304,7 @@ with tab3:
         logs = list_expense_logs(eid)
         if logs:
             log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details",{})} for l in logs]
+                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details_text", "")} for l in logs]
             )
             st.subheader("Historial (logs)")
             st.dataframe(log_df, use_container_width=True, hide_index=True)

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -180,7 +180,7 @@ with tab2:
         logs = list_expense_logs(expense_id)
         if logs:
             log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details",{})} for l in logs]
+                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details_text", "")} for l in logs]
             )
             st.dataframe(log_df, use_container_width=True, hide_index=True)
         else:
@@ -349,7 +349,7 @@ with tab3:
         logs = list_expense_logs(eid)
         if logs:
             log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details",{})} for l in logs]
+                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details_text", "")} for l in logs]
             )
             st.subheader("Historial (logs)")
             st.dataframe(log_df, use_container_width=True, hide_index=True)

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -247,8 +247,8 @@ with tab_detalle:
         st.caption("No hay historial.")
     else:
         for lg in logs:
-            det = lg.get("details") or {}
+            det_txt = lg.get("details_text", "")
             st.markdown(
                 f"- **{lg['created_at']}** — {lg['action']} — {lg.get('actor_email','(sin email)')}  "
-                + (f"— {det}" if det else "")
+                + (f"— {det_txt}" if det_txt else "")
             )


### PR DESCRIPTION
## Summary
- convert log `details` JSON to a human-friendly string
- display formatted details in approver, requester and payer log views

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71b1bed64832ea28407599ff3d06c