### PR TITLE
Store payment documents in dedicated bucket with download buttons

### DIFF
--- a/pages/lector.py
+++ b/pages/lector.py
@@ -1,6 +1,7 @@
 # pages/lector.py
 # Rol Lector: dashboard con filtros por fechas, comparativas y detalle
 
+import os
 import requests
 import pandas as pd
 import streamlit as st
@@ -39,13 +40,28 @@ def _render_preview_if_pdf(url: str, file_key: str, title: str):
     if not url:
         return
     st.link_button(f"Abrir {title} en pestaña nueva", url, use_container_width=True)
-    if file_key and file_key.lower().endswith(".pdf"):
-        try:
-            resp = requests.get(url, timeout=10)
-            resp.raise_for_status()
-            pdf_viewer(resp.content, width=700, height=900, pages_to_render=[1])
-        except Exception as e:
-            st.caption(f"No se pudo previsualizar el PDF de {title}: {e}")
+
+    file_bytes = None
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        file_bytes = resp.content
+    except Exception as e:
+        st.caption(f"No se pudo obtener el archivo de {title}: {e}")
+
+    if file_bytes:
+        fname = os.path.basename(file_key) if file_key else title.replace(" ", "_")
+        st.download_button(
+            f"Descargar {title}",
+            file_bytes,
+            file_name=fname,
+            use_container_width=True,
+        )
+        if file_key and file_key.lower().endswith(".pdf"):
+            try:
+                pdf_viewer(file_bytes, width=700, height=900, pages_to_render=[1])
+            except Exception as e:
+                st.caption(f"No se pudo previsualizar el PDF de {title}: {e}")
 
 # --------------------------
 # Filtros globales

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -4,6 +4,7 @@
 import os
 import uuid
 from decimal import Decimal
+import requests
 import streamlit as st
 import pandas as pd
 
@@ -14,6 +15,8 @@ from f_read import (
     recent_similar_expenses,
     signed_url_for_receipt,
     signed_url_for_payment,
+    receipt_file_key,
+    payment_file_key,
     get_my_expense,
     list_expense_comments,
     list_expense_logs,
@@ -202,15 +205,39 @@ with tab_detalle:
 )
 
     # Enlaces rápidos a archivos
+    rec_key = receipt_file_key(exp.get("supporting_doc_key") or "")
+    pay_key = payment_file_key(exp.get("payment_doc_key") or "")
     rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
     pay_url = signed_url_for_payment(exp.get("payment_doc_key") or "", 600)
     colf1, colf2 = st.columns(2)
     with colf1:
         if rec_url:
             st.link_button("Ver recibo", rec_url, use_container_width=True)
+            try:
+                resp = requests.get(rec_url, timeout=10)
+                resp.raise_for_status()
+                st.download_button(
+                    "Descargar recibo",
+                    resp.content,
+                    file_name=os.path.basename(rec_key) if rec_key else "recibo",
+                    use_container_width=True,
+                )
+            except Exception as e:
+                st.caption(f"No se pudo descargar el recibo: {e}")
     with colf2:
         if pay_url:
             st.link_button("Ver comprobante de pago", pay_url, use_container_width=True)
+            try:
+                resp = requests.get(pay_url, timeout=10)
+                resp.raise_for_status()
+                st.download_button(
+                    "Descargar comprobante",
+                    resp.content,
+                    file_name=os.path.basename(pay_key) if pay_key else "comprobante",
+                    use_container_width=True,
+                )
+            except Exception as e:
+                st.caption(f"No se pudo descargar el comprobante: {e}")
 
     st.divider()
 


### PR DESCRIPTION
## Summary
- store payment receipts in new `payments` storage bucket
- add download buttons when viewing receipt or payment files
- support signed URLs and lookups for `payments` bucket

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7212e5edc832e8d295ba83577a3c3