### PR TITLE
Store file keys instead of folders

### DIFF
--- a/f_read.py
+++ b/f_read.py
@@ -184,19 +184,6 @@ def recent_similar_expenses(supplier_id: str, amount: float, days: int = 30) -> 
     )
     return res.data or []
 
-def signed_url_for_receipt(key: str, expires: int = 300) -> Optional[str]:
-    """
-    Create a short-lived signed URL for a receipt path (bucket 'receipts').
-    """
-    if not key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("quotes").create_signed_url(key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
-
 def _emails_by_ids(ids: Iterable[str]) -> dict:
     ids = [i for i in ids if i]
     if not ids:
@@ -259,60 +246,6 @@ def list_expense_comments(expense_id: str) -> List[Dict[str, Any]]:
             "actor_email": emails.get(r["author_id"]),
         })
     return out
-
-
-def _first_object_in_folder(bucket: str, folder: str) -> Optional[str]:
-    """
-    Devuelve la ruta (key) del primer archivo dentro de 'folder' en el bucket.
-    Si 'folder' en realidad es ya un archivo, lo intentamos usar tal cual.
-    """
-    sb = get_client()
-    folder = (folder or "").strip().strip("/")  # normaliza
-    if not folder:
-        return None
-
-    # 1) Intento: listar archivos dentro del folder
-    try:
-        listing = sb.storage.from_(bucket).list(path=folder, sortBy={"column": "updated_at", "order": "desc"})
-        if listing:
-            # Tomamos el más reciente
-            name = listing[0].get("name")
-            if name:
-                return f"{folder}/{name}"
-    except Exception:
-        pass
-
-    # 2) Fallback: quizá 'folder' ya es una ruta de archivo
-    return folder  # lo usamos tal cual
-
-def signed_url_for_receipt(key_or_folder: str, expires: int = 300) -> Optional[str]:
-    """
-    Si key_or_folder es una carpeta, toma el primer archivo adentro y crea URL firmada.
-    Bucket: 'quotes' (tu caso actual).
-    """
-    file_key = _first_object_in_folder("quotes", key_or_folder)
-    if not file_key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("quotes").create_signed_url(file_key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
-
-def signed_url_for_payment(key_or_folder: str, expires: int = 300) -> Optional[str]:
-    """
-    Igual que el recibo. Si guardas el comprobante como carpeta, funciona igual.
-    """
-    file_key = _first_object_in_folder("quotes", key_or_folder)
-    if not file_key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("quotes").create_signed_url(file_key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
 
 ## APROBADOR
 
@@ -440,49 +373,24 @@ def list_expenses_by_requester(user_id: str) -> List[Dict[str, Any]]:
     for r in rows:
         r["requested_by_email"] = email
     return rows
-@st.cache_data(ttl=30, show_spinner=False)
-def _first_object_in_folder(bucket: str, key_or_folder: str) -> Optional[str]:
+def receipt_file_key(key: str) -> Optional[str]:
     """
-    Devuelve la key del primer archivo dentro de ``key_or_folder``.
-    Si ``key_or_folder`` ya es un archivo, la retorna tal cual.
-    Si existen subcarpetas, desciende hasta hallar un archivo.
+    Normaliza y retorna la key almacenada para el documento de respaldo.
+    Ya no se buscan archivos dentro de carpetas.
     """
-    sb = get_client()
-    path = (key_or_folder or "").strip().strip("/")
-    if not path:
-        return None
-
-    # Descender recursivamente hasta encontrar un archivo (máx. 10 niveles)
-    for _ in range(10):
-        try:
-            items = sb.storage.from_(bucket).list(
-                path=path, sortBy={"column": "updated_at", "order": "desc"}
-            )
-        except Exception:
-            return path if "/" in path else None
-
-        if not items:
-            return path if "/" in path else None
-
-        name = (items[0] or {}).get("name")
-        if not name:
-            return path if "/" in path else None
-
-        path = f"{path}/{name}"
-
-    return path if "/" in path else None
+    key = (key or "").strip().strip("/")
+    return key or None
 
 
-def receipt_file_key(key_or_folder: str) -> Optional[str]:
-    """Conveniencia: primer archivo del folder (bucket 'quotes') para el recibo/cotización."""
-    return _first_object_in_folder("quotes", key_or_folder)
+def payment_file_key(key: str) -> Optional[str]:
+    """Normaliza y retorna la key almacenada para el comprobante de pago."""
+    key = (key or "").strip().strip("/")
+    return key or None
 
 
-def signed_url_for_receipt(key_or_folder: str, expires: int = 600) -> Optional[str]:
-    """
-    Crea una URL firmada para el primer archivo dentro del folder guardado en expenses.supporting_doc_key.
-    """
-    file_key = receipt_file_key(key_or_folder)
+def signed_url_for_receipt(key: str, expires: int = 600) -> Optional[str]:
+    """Crea una URL firmada usando la key guardada en ``supporting_doc_key``."""
+    file_key = receipt_file_key(key)
     if not file_key:
         return None
     try:
@@ -493,11 +401,9 @@ def signed_url_for_receipt(key_or_folder: str, expires: int = 600) -> Optional[s
         return None
 
 
-def signed_url_for_payment(key_or_folder: str, expires: int = 600) -> Optional[str]:
-    """
-    Igual que arriba, pero para el comprobante de pago si lo guardas también como carpeta.
-    """
-    file_key = _first_object_in_folder("payments", key_or_folder)
+def signed_url_for_payment(key: str, expires: int = 600) -> Optional[str]:
+    """Crea una URL firmada usando la key guardada en ``payment_doc_key``."""
+    file_key = payment_file_key(key)
     if not file_key:
         return None
     try:
@@ -547,37 +453,6 @@ def render_quote_preview_if_pdf(supporting_doc_key: str):
                 )
             except Exception as e:
                 st.caption(f"No se pudo previsualizar el PDF: {e}")
-
-@st.cache_data(ttl=30, show_spinner=False)
-def payment_file_key(key_or_folder: str) -> Optional[str]:
-    """
-    Primer archivo dentro del folder de 'payment_doc_key' en el bucket 'payments'.
-    """
-    sb = get_client()
-    key = (key_or_folder or "").strip().strip("/")
-    if not key:
-        return None
-    try:
-        items = sb.storage.from_("payments").list(path=key, sortBy={"column": "updated_at", "order": "desc"})
-        for it in (items or []):
-            name = it.get("name")
-            if name:
-                return f"{key}/{name}"
-    except Exception:
-        pass
-    return key if "/" in key else None
-
-def signed_url_for_payment(key_or_folder: str, expires: int = 600) -> Optional[str]:
-    file_key = payment_file_key(key_or_folder)
-    if not file_key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("payments").create_signed_url(file_key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
-
 
 def _emails_by_ids(ids: Iterable[str]) -> dict:
     ids = [i for i in ids if i]

--- a/pages/lector.py
+++ b/pages/lector.py
@@ -14,8 +14,6 @@ from f_read import (
     list_requesters_for_approver,   # reutilizamos para obtener solicitantes
     list_approvers_for_viewer,      # NUEVO helper abajo
     list_paid_expenses_enriched,    # NUEVO helper abajo
-    receipt_file_key,
-    payment_file_key,
     signed_url_for_receipt,
     signed_url_for_payment,
 )
@@ -245,11 +243,11 @@ with tab_detalle:
 
     st.divider()
     st.caption("Documento de respaldo")
-    rec_key = receipt_file_key(row.get("supporting_doc_key") or "")
-    rec_url = signed_url_for_receipt(row.get("supporting_doc_key") or "", 600)
+    rec_key = row.get("supporting_doc_key") or ""
+    rec_url = signed_url_for_receipt(rec_key, 600)
     _render_preview_if_pdf(rec_url, rec_key or "", "documento de respaldo")
 
     st.caption("Comprobante de pago")
-    pay_key = payment_file_key(row.get("payment_doc_key") or "")
-    pay_url = signed_url_for_payment(row.get("payment_doc_key") or "", 600)
+    pay_key = row.get("payment_doc_key") or ""
+    pay_url = signed_url_for_payment(pay_key, 600)
     _render_preview_if_pdf(pay_url, pay_key or "", "comprobante de pago")

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -22,8 +22,6 @@ from f_read import (
     list_expenses_by_requester,
     signed_url_for_receipt,
     signed_url_for_payment,
-    receipt_file_key,
-    payment_file_key,
 )
 
 from f_cud import mark_expense_as_paid, add_expense_comment
@@ -179,15 +177,15 @@ with tab2:
 
         # Quote/recibo
         st.caption("Documento de respaldo")
-        rec_key = receipt_file_key(exp.get("supporting_doc_key") or "")
-        rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
+        rec_key = exp.get("supporting_doc_key") or ""
+        rec_url = signed_url_for_receipt(rec_key, 600)
         _render_preview_if_pdf(rec_url, rec_key or "", "documento de respaldo")
 
         # Comprobante de pago (si existe)
         if exp.get("payment_doc_key"):
             st.caption("Comprobante de pago")
-            pay_key = payment_file_key(exp.get("payment_doc_key") or "")
-            pay_url = signed_url_for_payment(exp.get("payment_doc_key") or "", 600)
+            pay_key = exp.get("payment_doc_key") or ""
+            pay_url = signed_url_for_payment(pay_key, 600)
             _render_preview_if_pdf(pay_url, pay_key or "", "comprobante de pago")
 
         st.divider()
@@ -242,18 +240,23 @@ with tab2:
                         st.error("Debes adjuntar un comprobante para marcar como pagado.")
                         st.stop()
 
-                    # Subir archivo al bucket 'payments' en una CARPETA y guardar la carpeta
+                    # Subir archivo al bucket 'payments' y guardar la key completa
                     sb = get_client()
                     bucket = "payments"
                     folder = f"{expense_id}/pago-{uuid.uuid4().hex}"
                     file_path = f"{folder}/{pay_file.name}"
-                    sb.storage.from_(bucket).upload(file_path, pay_file.getvalue())
+                    res = sb.storage.from_(bucket).upload(file_path, pay_file.getvalue())
+                    stored_key = (
+                        (res or {}).get("path")
+                        or (res or {}).get("Key")
+                        or file_path
+                    )
 
                     # Actualizar estado + payment_doc_key y log
                     mark_expense_as_paid(
                         expense_id=expense_id,
                         actor_id=user_id,
-                        payment_doc_folder=folder,
+                        payment_doc_key=stored_key,
                         comment=(comment or "").strip() or None,
                     )
                     st.success("Solicitud marcada como pagada.")
@@ -350,14 +353,14 @@ with tab3:
             f"**Creado:** {_fmt_dt(exp['created_at'])}"
         )
         st.caption("Documento de respaldo")
-        rec_key = receipt_file_key(exp.get("supporting_doc_key") or "")
-        rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
+        rec_key = exp.get("supporting_doc_key") or ""
+        rec_url = signed_url_for_receipt(rec_key, 600)
         _render_preview_if_pdf(rec_url, rec_key or "", "documento de respaldo")
 
         if exp.get("payment_doc_key"):
             st.caption("Comprobante de pago")
-            pay_key = payment_file_key(exp.get("payment_doc_key") or "")
-            pay_url = signed_url_for_payment(exp.get("payment_doc_key") or "", 600)
+            pay_key = exp.get("payment_doc_key") or ""
+            pay_url = signed_url_for_payment(pay_key, 600)
             _render_preview_if_pdf(pay_url, pay_key or "", "comprobante de pago")
 
         st.divider()

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -15,8 +15,6 @@ from f_read import (
     recent_similar_expenses,
     signed_url_for_receipt,
     signed_url_for_payment,
-    receipt_file_key,
-    payment_file_key,
     get_my_expense,
     list_expense_comments,
     list_expense_logs,
@@ -96,14 +94,19 @@ with tab_nueva:
                 file_name = file.name                                 # preserva nombre original
                 file_path = f"{folder}/{file_name}"                   # archivo dentro de la carpeta
 
-                sb.storage.from_(bucket).upload(file_path, file.getvalue())
+                res = sb.storage.from_(bucket).upload(file_path, file.getvalue())
+                stored_key = (
+                    (res or {}).get("path")
+                    or (res or {}).get("Key")
+                    or file_path
+                )
 
                 expense_id = create_expense(
                     requested_by=user_id,
                     supplier_id=supplier_id,
                     amount=float(Decimal(str(amount))),
                     category=categoria,
-                    supporting_doc_key=folder,  # <<< guardamos SOLO la carpeta
+                    supporting_doc_key=stored_key,  # guardamos la key completa
                     description=descripcion.strip() if descripcion else None,
                 )
 
@@ -205,10 +208,10 @@ with tab_detalle:
 )
 
     # Enlaces rápidos a archivos
-    rec_key = receipt_file_key(exp.get("supporting_doc_key") or "")
-    pay_key = payment_file_key(exp.get("payment_doc_key") or "")
-    rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
-    pay_url = signed_url_for_payment(exp.get("payment_doc_key") or "", 600)
+    rec_key = exp.get("supporting_doc_key") or ""
+    pay_key = exp.get("payment_doc_key") or ""
+    rec_url = signed_url_for_receipt(rec_key, 600)
+    pay_url = signed_url_for_payment(pay_key, 600)
     colf1, colf2 = st.columns(2)
     with colf1:
         if rec_url:


### PR DESCRIPTION
## Summary
- Save full storage object keys for receipts and payments
- Simplify file key utilities and signed URL helpers
- Update pages to upload and use direct file keys

## Testing
- `python -m py_compile f_cud.py f_read.py pages/solicitante.py pages/pagador.py pages/lector.py`


------
https://chatgpt.com/codex/tasks/task_e_68b746e6a5f8832e8b6591654a0a1eea