### PR TITLE
Store file keys instead of folders

### DIFF
--- a/f_read.py
+++ b/f_read.py
@@ -1,11 +1,8 @@
-import os
 import streamlit as st
 from typing import List, Dict, Any, Optional, Tuple, Set, Iterable
 from f_auth import get_client
 from collections import defaultdict
 import datetime as dt
-import requests
-from streamlit_pdf_viewer import pdf_viewer
 import pandas as pd
 
 # ==========================
@@ -184,19 +181,6 @@ def recent_similar_expenses(supplier_id: str, amount: float, days: int = 30) -> 
     )
     return res.data or []
 
-def signed_url_for_receipt(key: str, expires: int = 300) -> Optional[str]:
-    """
-    Create a short-lived signed URL for a receipt path (bucket 'receipts').
-    """
-    if not key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("quotes").create_signed_url(key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
-
 def _emails_by_ids(ids: Iterable[str]) -> dict:
     ids = [i for i in ids if i]
     if not ids:
@@ -259,60 +243,6 @@ def list_expense_comments(expense_id: str) -> List[Dict[str, Any]]:
             "actor_email": emails.get(r["author_id"]),
         })
     return out
-
-
-def _first_object_in_folder(bucket: str, folder: str) -> Optional[str]:
-    """
-    Devuelve la ruta (key) del primer archivo dentro de 'folder' en el bucket.
-    Si 'folder' en realidad es ya un archivo, lo intentamos usar tal cual.
-    """
-    sb = get_client()
-    folder = (folder or "").strip().strip("/")  # normaliza
-    if not folder:
-        return None
-
-    # 1) Intento: listar archivos dentro del folder
-    try:
-        listing = sb.storage.from_(bucket).list(path=folder, sortBy={"column": "updated_at", "order": "desc"})
-        if listing:
-            # Tomamos el más reciente
-            name = listing[0].get("name")
-            if name:
-                return f"{folder}/{name}"
-    except Exception:
-        pass
-
-    # 2) Fallback: quizá 'folder' ya es una ruta de archivo
-    return folder  # lo usamos tal cual
-
-def signed_url_for_receipt(key_or_folder: str, expires: int = 300) -> Optional[str]:
-    """
-    Si key_or_folder es una carpeta, toma el primer archivo adentro y crea URL firmada.
-    Bucket: 'quotes' (tu caso actual).
-    """
-    file_key = _first_object_in_folder("quotes", key_or_folder)
-    if not file_key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("quotes").create_signed_url(file_key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
-
-def signed_url_for_payment(key_or_folder: str, expires: int = 300) -> Optional[str]:
-    """
-    Igual que el recibo. Si guardas el comprobante como carpeta, funciona igual.
-    """
-    file_key = _first_object_in_folder("quotes", key_or_folder)
-    if not file_key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("quotes").create_signed_url(file_key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
 
 ## APROBADOR
 
@@ -440,49 +370,24 @@ def list_expenses_by_requester(user_id: str) -> List[Dict[str, Any]]:
     for r in rows:
         r["requested_by_email"] = email
     return rows
-@st.cache_data(ttl=30, show_spinner=False)
-def _first_object_in_folder(bucket: str, key_or_folder: str) -> Optional[str]:
+def receipt_file_key(key: str) -> Optional[str]:
     """
-    Devuelve la key del primer archivo dentro de ``key_or_folder``.
-    Si ``key_or_folder`` ya es un archivo, la retorna tal cual.
-    Si existen subcarpetas, desciende hasta hallar un archivo.
+    Normaliza y retorna la key almacenada para el documento de respaldo.
+    Ya no se buscan archivos dentro de carpetas.
     """
-    sb = get_client()
-    path = (key_or_folder or "").strip().strip("/")
-    if not path:
-        return None
-
-    # Descender recursivamente hasta encontrar un archivo (máx. 10 niveles)
-    for _ in range(10):
-        try:
-            items = sb.storage.from_(bucket).list(
-                path=path, sortBy={"column": "updated_at", "order": "desc"}
-            )
-        except Exception:
-            return path if "/" in path else None
-
-        if not items:
-            return path if "/" in path else None
-
-        name = (items[0] or {}).get("name")
-        if not name:
-            return path if "/" in path else None
-
-        path = f"{path}/{name}"
-
-    return path if "/" in path else None
+    key = (key or "").strip().strip("/")
+    return key or None
 
 
-def receipt_file_key(key_or_folder: str) -> Optional[str]:
-    """Conveniencia: primer archivo del folder (bucket 'quotes') para el recibo/cotización."""
-    return _first_object_in_folder("quotes", key_or_folder)
+def payment_file_key(key: str) -> Optional[str]:
+    """Normaliza y retorna la key almacenada para el comprobante de pago."""
+    key = (key or "").strip().strip("/")
+    return key or None
 
 
-def signed_url_for_receipt(key_or_folder: str, expires: int = 600) -> Optional[str]:
-    """
-    Crea una URL firmada para el primer archivo dentro del folder guardado en expenses.supporting_doc_key.
-    """
-    file_key = receipt_file_key(key_or_folder)
+def signed_url_for_receipt(key: str, expires: int = 600) -> Optional[str]:
+    """Crea una URL firmada usando la key guardada en ``supporting_doc_key``."""
+    file_key = receipt_file_key(key)
     if not file_key:
         return None
     try:
@@ -493,11 +398,9 @@ def signed_url_for_receipt(key_or_folder: str, expires: int = 600) -> Optional[s
         return None
 
 
-def signed_url_for_payment(key_or_folder: str, expires: int = 600) -> Optional[str]:
-    """
-    Igual que arriba, pero para el comprobante de pago si lo guardas también como carpeta.
-    """
-    file_key = _first_object_in_folder("payments", key_or_folder)
+def signed_url_for_payment(key: str, expires: int = 600) -> Optional[str]:
+    """Crea una URL firmada usando la key guardada en ``payment_doc_key``."""
+    file_key = payment_file_key(key)
     if not file_key:
         return None
     try:
@@ -507,76 +410,6 @@ def signed_url_for_payment(key_or_folder: str, expires: int = 600) -> Optional[s
     except Exception:
         return None
 
-
-def render_quote_preview_if_pdf(supporting_doc_key: str):
-    """
-    Si el quote es PDF, muestra la primera página con streamlit-pdf-viewer y
-    siempre muestra un botón para abrir el archivo en una pestaña nueva.
-    """
-    file_key = receipt_file_key(supporting_doc_key)
-    url = signed_url_for_receipt(supporting_doc_key, expires=600)
-    if not url:
-        return
-
-    # Link siempre
-    st.link_button("Abrir documento en pestaña nueva", url, use_container_width=True)
-
-    file_bytes = None
-    try:
-        resp = requests.get(url, timeout=10)
-        resp.raise_for_status()
-        file_bytes = resp.content
-    except Exception as e:
-        st.caption(f"No se pudo obtener el documento: {e}")
-
-    if file_bytes:
-        fname = os.path.basename(file_key) if file_key else "documento"
-        st.download_button(
-            "Descargar documento",
-            file_bytes,
-            file_name=fname,
-            use_container_width=True,
-        )
-        if file_key and file_key.lower().endswith(".pdf"):
-            try:
-                pdf_viewer(
-                    file_bytes,
-                    width=700,            # ver nota en PyPI: definir width dentro de tabs
-                    height=900,
-                    pages_to_render=[1],  # solo la primera página
-                )
-            except Exception as e:
-                st.caption(f"No se pudo previsualizar el PDF: {e}")
-
-@st.cache_data(ttl=30, show_spinner=False)
-def payment_file_key(key_or_folder: str) -> Optional[str]:
-    """
-    Primer archivo dentro del folder de 'payment_doc_key' en el bucket 'payments'.
-    """
-    sb = get_client()
-    key = (key_or_folder or "").strip().strip("/")
-    if not key:
-        return None
-    try:
-        items = sb.storage.from_("payments").list(path=key, sortBy={"column": "updated_at", "order": "desc"})
-        for it in (items or []):
-            name = it.get("name")
-            if name:
-                return f"{key}/{name}"
-    except Exception:
-        pass
-    return key if "/" in key else None
-
-def signed_url_for_payment(key_or_folder: str, expires: int = 600) -> Optional[str]:
-    file_key = payment_file_key(key_or_folder)
-    if not file_key:
-        return None
-    try:
-        sb = get_client()
-        out = sb.storage.from_("payments").create_signed_url(file_key, expires)
-        return (out or {}).get("signed_url")
-    except Exception:
-        return None
 
 
 def _emails_by_ids(ids: Iterable[str]) -> dict:

--- a/pages/lector.py
+++ b/pages/lector.py
@@ -5,7 +5,6 @@ import os
 import requests
 import pandas as pd
 import streamlit as st
-from streamlit_pdf_viewer import pdf_viewer
 
 from f_auth import require_lector, current_user
 from f_read import (
@@ -14,8 +13,6 @@ from f_read import (
     list_requesters_for_approver,   # reutilizamos para obtener solicitantes
     list_approvers_for_viewer,      # NUEVO helper abajo
     list_paid_expenses_enriched,    # NUEVO helper abajo
-    receipt_file_key,
-    payment_file_key,
     signed_url_for_receipt,
     signed_url_for_payment,
 )
@@ -36,33 +33,29 @@ def _fmt_dt(dt_str: str) -> str:
     except Exception:
         return dt_str
 
-def _render_preview_if_pdf(url: str, file_key: str, title: str):
-    """Renderiza un link, botón de descarga y vista previa del PDF."""
-    if not url:
-        return
-    st.link_button(f"Abrir {title} en pestaña nueva", url, use_container_width=True)
-
-    file_bytes = None
-    try:
-        resp = requests.get(url, timeout=10)
-        resp.raise_for_status()
-        file_bytes = resp.content
-    except Exception as e:
-        st.caption(f"No se pudo obtener el archivo de {title}: {e}")
-
-    if file_bytes:
-        fname = os.path.basename(file_key) if file_key else title.replace(" ", "_")
+def _render_download(url: str, file_key: str, title: str):
+    """Renderiza link y botón de descarga; deshabilita si no hay archivo."""
+    if url:
+        st.link_button(f"Abrir {title} en pestaña nueva", url, use_container_width=True)
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            st.download_button(
+                f"Descargar {title}",
+                resp.content,
+                file_name=os.path.basename(file_key) if file_key else title.replace(" ", "_"),
+                use_container_width=True,
+            )
+        except Exception as e:
+            st.caption(f"No se pudo obtener el archivo de {title}: {e}")
+    else:
         st.download_button(
             f"Descargar {title}",
-            file_bytes,
-            file_name=fname,
+            b"",
+            file_name=title.replace(" ", "_"),
             use_container_width=True,
+            disabled=True,
         )
-        if file_key and file_key.lower().endswith(".pdf"):
-            try:
-                pdf_viewer(file_bytes, width=700, height=900, pages_to_render=[1])
-            except Exception as e:
-                st.caption(f"No se pudo previsualizar el PDF de {title}: {e}")
 
 # --------------------------
 # Filtros globales
@@ -128,73 +121,72 @@ if df.empty:
     st.stop()
 
 # --------------------------
-# Métricas globales
+# Tabs: Reporte y Detalle
 # --------------------------
-m1, m2, m3, m4 = st.columns(4)
-m1.metric("Gastos (conteo)", f"{len(df):,}")
-m2.metric("Monto total", f"{df['amount'].sum():,.2f}")
-m3.metric("Monto promedio", f"{df['amount'].mean():,.2f}")
-m4.metric("Monto mediano", f"{df['amount'].median():,.2f}")
+tab_reporte, tab_detalle = st.tabs(["Reporte", "Detalle"])
 
-st.divider()
+# === Tab Reporte ===
+with tab_reporte:
+    m1, m2, m3, m4 = st.columns(4)
+    m1.metric("Gastos (conteo)", f"{len(df):,}")
+    m2.metric("Monto total", f"{df['amount'].sum():,.2f}")
+    m3.metric("Monto promedio", f"{df['amount'].mean():,.2f}")
+    m4.metric("Monto mediano", f"{df['amount'].median():,.2f}")
 
-# --------------------------
-# Tabs: Resumen, Comparar, Detalle
-# --------------------------
-tab_resumen, tab_comparar, tab_detalle = st.tabs(["Resumen", "Comparar", "Detalle"])
+    st.divider()
 
-# === Tab Resumen: tablas rápidas ===
-with tab_resumen:
-    st.subheader("Resumen por dimensión")
+    tab_resumen, tab_comparar = st.tabs(["Resumen", "Comparar"])
 
-    def _top_table(series, title, n=10):
-        if series.empty:
-            st.caption(f"Sin datos para {title}.")
-            return
-        tb = (series.value_counts().head(n)).rename("Gastos")
-        st.write(f"**Top {n} por {title}**")
-        st.dataframe(tb, use_container_width=True)
+    with tab_resumen:
+        st.subheader("Resumen por dimensión")
 
-    cA, cB, cC = st.columns(3)
-    with cA:
-        _top_table(df["supplier_name"], "Proveedor")
-    with cB:
-        _top_table(df["requested_by_email"], "Solicitante")
-    with cC:
-        _top_table(df["approved_by_email"], "Aprobador")
+        def _top_table(series, title, n=10):
+            if series.empty:
+                st.caption(f"Sin datos para {title}.")
+                return
+            tb = (series.value_counts().head(n)).rename("Gastos")
+            st.write(f"**Top {n} por {title}**")
+            st.dataframe(tb, use_container_width=True)
 
-    st.subheader("Evolución (por fecha de pago)")
-    ts = df.copy()
-    ts["paid_date"] = pd.to_datetime(ts["paid_at"]).dt.date
-    if not ts.empty:
-        grp = ts.groupby("paid_date").agg(
-            gastos=("id", "count"),
-            monto=("amount", "sum")
-        ).reset_index()
-        c1, c2 = st.columns(2)
-        with c1:
-            st.line_chart(grp, x="paid_date", y="gastos", use_container_width=True)
-        with c2:
-            st.line_chart(grp, x="paid_date", y="monto", use_container_width=True)
-    else:
-        st.caption("Sin datos para serie temporal.")
+        cA, cB, cC = st.columns(3)
+        with cA:
+            _top_table(df["supplier_name"], "Proveedor")
+        with cB:
+            _top_table(df["requested_by_email"], "Solicitante")
+        with cC:
+            _top_table(df["approved_by_email"], "Aprobador")
 
-# === Tab Comparar: barras por dimensión ===
-with tab_comparar:
-    st.subheader("Comparar por dimensión")
+        st.subheader("Evolución (por fecha de pago)")
+        ts = df.copy()
+        ts["paid_date"] = pd.to_datetime(ts["paid_at"]).dt.date
+        if not ts.empty:
+            grp = ts.groupby("paid_date").agg(
+                gastos=("id", "count"),
+                monto=("amount", "sum")
+            ).reset_index()
+            c1, c2 = st.columns(2)
+            with c1:
+                st.line_chart(grp, x="paid_date", y="gastos", use_container_width=True)
+            with c2:
+                st.line_chart(grp, x="paid_date", y="monto", use_container_width=True)
+        else:
+            st.caption("Sin datos para serie temporal.")
 
-    dim = st.radio("Dimensión", options=["Proveedores", "Solicitantes", "Aprobadores", "Categorías"], horizontal=True)
+    with tab_comparar:
+        st.subheader("Comparar por dimensión")
 
-    if dim == "Proveedores":
-        ser = df.groupby("supplier_name")["amount"].sum().sort_values(ascending=False)
-    elif dim == "Solicitantes":
-        ser = df.groupby("requested_by_email")["amount"].sum().sort_values(ascending=False)
-    elif dim == "Aprobadores":
-        ser = df.groupby("approved_by_email")["amount"].sum().sort_values(ascending=False)
-    else:
-        ser = df.groupby("category")["amount"].sum().sort_values(ascending=False)
+        dim = st.radio("Dimensión", options=["Proveedores", "Solicitantes", "Aprobadores", "Categorías"], horizontal=True)
 
-    st.bar_chart(ser.head(20), use_container_width=True)
+        if dim == "Proveedores":
+            ser = df.groupby("supplier_name")["amount"].sum().sort_values(ascending=False)
+        elif dim == "Solicitantes":
+            ser = df.groupby("requested_by_email")["amount"].sum().sort_values(ascending=False)
+        elif dim == "Aprobadores":
+            ser = df.groupby("approved_by_email")["amount"].sum().sort_values(ascending=False)
+        else:
+            ser = df.groupby("category")["amount"].sum().sort_values(ascending=False)
+
+        st.bar_chart(ser.head(20), use_container_width=True)
 
 # === Tab Detalle: tabla y detalle de un gasto ===
 with tab_detalle:
@@ -245,11 +237,11 @@ with tab_detalle:
 
     st.divider()
     st.caption("Documento de respaldo")
-    rec_key = receipt_file_key(row.get("supporting_doc_key") or "")
-    rec_url = signed_url_for_receipt(row.get("supporting_doc_key") or "", 600)
-    _render_preview_if_pdf(rec_url, rec_key or "", "documento de respaldo")
+    rec_key = row.get("supporting_doc_key") or ""
+    rec_url = signed_url_for_receipt(rec_key, 600)
+    _render_download(rec_url, rec_key or "", "documento de respaldo")
 
     st.caption("Comprobante de pago")
-    pay_key = payment_file_key(row.get("payment_doc_key") or "")
-    pay_url = signed_url_for_payment(row.get("payment_doc_key") or "", 600)
-    _render_preview_if_pdf(pay_url, pay_key or "", "comprobante de pago")
+    pay_key = row.get("payment_doc_key") or ""
+    pay_url = signed_url_for_payment(pay_key, 600)
+    _render_download(pay_url, pay_key or "", "comprobante de pago")

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -6,7 +6,6 @@ import uuid
 import requests
 import pandas as pd
 import streamlit as st
-from streamlit_pdf_viewer import pdf_viewer
 
 from f_auth import require_pagador, current_user, get_client
 from f_read import (
@@ -22,8 +21,6 @@ from f_read import (
     list_expenses_by_requester,
     signed_url_for_receipt,
     signed_url_for_payment,
-    receipt_file_key,
-    payment_file_key,
 )
 
 from f_cud import mark_expense_as_paid, add_expense_comment
@@ -44,40 +41,29 @@ def _fmt_dt(s: str) -> str:
     except Exception:
         return s
 
-def _render_preview_if_pdf(url: str, file_key: str, title: str):
-    """
-    Muestra link, botón de descarga y vista de la primera página si es PDF.
-    """
-    if not url:
-        return
-    st.link_button(f"Abrir {title} en pestaña nueva", url, use_container_width=True)
-
-    file_bytes = None
-    try:
-        resp = requests.get(url, timeout=10)
-        resp.raise_for_status()
-        file_bytes = resp.content
-    except Exception as e:
-        st.caption(f"No se pudo obtener el archivo de {title}: {e}")
-
-    if file_bytes:
-        fname = os.path.basename(file_key) if file_key else title.replace(" ", "_")
+def _render_download(url: str, file_key: str, title: str):
+    """Renderiza link y botón de descarga; deshabilita si no hay archivo."""
+    if url:
+        st.link_button(f"Abrir {title} en pestaña nueva", url, use_container_width=True)
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            st.download_button(
+                f"Descargar {title}",
+                resp.content,
+                file_name=os.path.basename(file_key) if file_key else title.replace(" ", "_"),
+                use_container_width=True,
+            )
+        except Exception as e:
+            st.caption(f"No se pudo obtener el archivo de {title}: {e}")
+    else:
         st.download_button(
             f"Descargar {title}",
-            file_bytes,
-            file_name=fname,
+            b"",
+            file_name=title.replace(" ", "_"),
             use_container_width=True,
+            disabled=True,
         )
-        if file_key and file_key.lower().endswith(".pdf"):
-            try:
-                pdf_viewer(
-                    file_bytes,
-                    width=700,
-                    height=900,
-                    pages_to_render=[1],
-                )
-            except Exception as e:
-                st.caption(f"No se pudo previsualizar el PDF de {title}: {e}")
 
 # ---------------------------------------------------
 # Tabs
@@ -179,16 +165,15 @@ with tab2:
 
         # Quote/recibo
         st.caption("Documento de respaldo")
-        rec_key = receipt_file_key(exp.get("supporting_doc_key") or "")
-        rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
-        _render_preview_if_pdf(rec_url, rec_key or "", "documento de respaldo")
+        rec_key = exp.get("supporting_doc_key") or ""
+        rec_url = signed_url_for_receipt(rec_key, 600)
+        _render_download(rec_url, rec_key, "documento de respaldo")
 
-        # Comprobante de pago (si existe)
-        if exp.get("payment_doc_key"):
-            st.caption("Comprobante de pago")
-            pay_key = payment_file_key(exp.get("payment_doc_key") or "")
-            pay_url = signed_url_for_payment(exp.get("payment_doc_key") or "", 600)
-            _render_preview_if_pdf(pay_url, pay_key or "", "comprobante de pago")
+        # Comprobante de pago
+        st.caption("Comprobante de pago")
+        pay_key = exp.get("payment_doc_key") or ""
+        pay_url = signed_url_for_payment(pay_key, 600)
+        _render_download(pay_url, pay_key, "comprobante de pago")
 
         st.divider()
         st.subheader("Historial (logs)")
@@ -242,18 +227,26 @@ with tab2:
                         st.error("Debes adjuntar un comprobante para marcar como pagado.")
                         st.stop()
 
-                    # Subir archivo al bucket 'payments' en una CARPETA y guardar la carpeta
+                    # Subir archivo al bucket 'payments' y guardar la key completa
                     sb = get_client()
                     bucket = "payments"
                     folder = f"{expense_id}/pago-{uuid.uuid4().hex}"
                     file_path = f"{folder}/{pay_file.name}"
-                    sb.storage.from_(bucket).upload(file_path, pay_file.getvalue())
+                    res = sb.storage.from_(bucket).upload(file_path, pay_file.getvalue())
+                    stored_key = (
+                        (getattr(res, "path", None) if res else None)
+                        or (getattr(res, "Key", None) if res else None)
+                        or (getattr(res, "key", None) if res else None)
+                        or (res.get("path") if isinstance(res, dict) else None)
+                        or (res.get("Key") if isinstance(res, dict) else None)
+                        or file_path
+                    )
 
                     # Actualizar estado + payment_doc_key y log
                     mark_expense_as_paid(
                         expense_id=expense_id,
                         actor_id=user_id,
-                        payment_doc_folder=folder,
+                        payment_doc_key=stored_key,
                         comment=(comment or "").strip() or None,
                     )
                     st.success("Solicitud marcada como pagada.")
@@ -350,15 +343,14 @@ with tab3:
             f"**Creado:** {_fmt_dt(exp['created_at'])}"
         )
         st.caption("Documento de respaldo")
-        rec_key = receipt_file_key(exp.get("supporting_doc_key") or "")
-        rec_url = signed_url_for_receipt(exp.get("supporting_doc_key") or "", 600)
-        _render_preview_if_pdf(rec_url, rec_key or "", "documento de respaldo")
+        rec_key = exp.get("supporting_doc_key") or ""
+        rec_url = signed_url_for_receipt(rec_key, 600)
+        _render_download(rec_url, rec_key, "documento de respaldo")
 
-        if exp.get("payment_doc_key"):
-            st.caption("Comprobante de pago")
-            pay_key = payment_file_key(exp.get("payment_doc_key") or "")
-            pay_url = signed_url_for_payment(exp.get("payment_doc_key") or "", 600)
-            _render_preview_if_pdf(pay_url, pay_key or "", "comprobante de pago")
+        st.caption("Comprobante de pago")
+        pay_key = exp.get("payment_doc_key") or ""
+        pay_url = signed_url_for_payment(pay_key, 600)
+        _render_download(pay_url, pay_key, "comprobante de pago")
 
         st.divider()
         logs = list_expense_logs(eid)


### PR DESCRIPTION
## Summary
- Save uploaded file's object key returned by Supabase
- Access `UploadResponse` attributes instead of dict methods when capturing keys
- Continue to pass stored keys to signed URL helpers
- Drop PDF viewer dependency and offer download links for quotes and payments across roles

## Testing
- `python -m py_compile f_cud.py f_read.py pages/solicitante.py pages/pagador.py pages/lector.py pages/aprobador.py`


------
https://chatgpt.com/codex/tasks/task_e_68b746e6a5f8832e8b6591654a0a1eea