### PR TITLE
Avoid duplicate Streamlit download IDs

### DIFF
--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -2,6 +2,8 @@
 # Rol Aprobador: métricas, listas por estado, detalles+actualizar, historial
 
 import os
+import uuid
+
 import pandas as pd
 import streamlit as st
 from f_auth import require_aprobador, current_user
@@ -36,6 +38,7 @@ ESTADOS = ["solicitado", "aprobado", "rechazado", "pagado"]
 
 
 def _render_download(url: str, key: str, label: str):
+    dl_key = f"dl-{label}-{uuid.uuid4().hex}"
     if url:
         st.link_button(f"Abrir {label}", url, use_container_width=True)
         try:
@@ -46,6 +49,7 @@ def _render_download(url: str, key: str, label: str):
                 resp.content,
                 file_name=os.path.basename(key) if key else label.replace(" ", "_"),
                 use_container_width=True,
+                key=dl_key,
             )
         except Exception as e:
             st.caption(f"No se pudo descargar {label}: {e}")
@@ -55,6 +59,7 @@ def _render_download(url: str, key: str, label: str):
             b"",
             use_container_width=True,
             disabled=True,
+            key=dl_key,
         )
 
 # ---------------------------------------------------

--- a/pages/lector.py
+++ b/pages/lector.py
@@ -2,6 +2,8 @@
 # Rol Lector: dashboard con filtros por fechas, comparativas y detalle
 
 import os
+import uuid
+
 import requests
 import pandas as pd
 import streamlit as st
@@ -35,6 +37,7 @@ def _fmt_dt(dt_str: str) -> str:
 
 def _render_download(url: str, file_key: str, title: str):
     """Renderiza link y botón de descarga; deshabilita si no hay archivo."""
+    dl_key = f"dl-{title}-{uuid.uuid4().hex}"
     if url:
         st.link_button(f"Abrir {title} en pestaña nueva", url, use_container_width=True)
         try:
@@ -45,6 +48,7 @@ def _render_download(url: str, file_key: str, title: str):
                 resp.content,
                 file_name=os.path.basename(file_key) if file_key else title.replace(" ", "_"),
                 use_container_width=True,
+                key=dl_key,
             )
         except Exception as e:
             st.caption(f"No se pudo obtener el archivo de {title}: {e}")
@@ -55,6 +59,7 @@ def _render_download(url: str, file_key: str, title: str):
             file_name=title.replace(" ", "_"),
             use_container_width=True,
             disabled=True,
+            key=dl_key,
         )
 
 # --------------------------

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -43,6 +43,7 @@ def _fmt_dt(s: str) -> str:
 
 def _render_download(url: str, file_key: str, title: str):
     """Renderiza link y botón de descarga; deshabilita si no hay archivo."""
+    dl_key = f"dl-{title}-{uuid.uuid4().hex}"
     if url:
         st.link_button(f"Abrir {title} en pestaña nueva", url, use_container_width=True)
         try:
@@ -53,6 +54,7 @@ def _render_download(url: str, file_key: str, title: str):
                 resp.content,
                 file_name=os.path.basename(file_key) if file_key else title.replace(" ", "_"),
                 use_container_width=True,
+                key=dl_key,
             )
         except Exception as e:
             st.caption(f"No se pudo obtener el archivo de {title}: {e}")
@@ -63,6 +65,7 @@ def _render_download(url: str, file_key: str, title: str):
             file_name=title.replace(" ", "_"),
             use_container_width=True,
             disabled=True,
+            key=dl_key,
         )
 
 # ---------------------------------------------------

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -229,6 +229,7 @@ with tab_detalle:
                     resp.content,
                     file_name=os.path.basename(rec_key) if rec_key else "recibo",
                     use_container_width=True,
+                    key=f"dl-recibo-{uuid.uuid4().hex}",
                 )
             except Exception as e:
                 st.caption(f"No se pudo descargar el recibo: {e}")
@@ -239,6 +240,7 @@ with tab_detalle:
                 file_name="recibo",
                 use_container_width=True,
                 disabled=True,
+                key=f"dl-recibo-{uuid.uuid4().hex}",
             )
     with colf2:
         if pay_url:
@@ -251,6 +253,7 @@ with tab_detalle:
                     resp.content,
                     file_name=os.path.basename(pay_key) if pay_key else "comprobante",
                     use_container_width=True,
+                    key=f"dl-comprobante-{uuid.uuid4().hex}",
                 )
             except Exception as e:
                 st.caption(f"No se pudo descargar el comprobante: {e}")
@@ -261,6 +264,7 @@ with tab_detalle:
                 file_name="comprobante",
                 use_container_width=True,
                 disabled=True,
+                key=f"dl-comprobante-{uuid.uuid4().hex}",
             )
 
     st.divider()


### PR DESCRIPTION
## Summary
- Generate a UUID-based key for each download button to avoid `StreamlitDuplicateElementId` errors
- Apply unique keys across approver, payer, viewer, and requester pages

## Testing
- `python -m py_compile pages/aprobador.py pages/pagador.py pages/lector.py pages/solicitante.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74f8645ec832ea0185331a4445c61