### PR TITLE
Retrieve payment document key for approver lookup

### DIFF
--- a/f_read.py
+++ b/f_read.py
@@ -299,7 +299,7 @@ def list_expenses_for_status(status: Optional[str]) -> List[Dict[str, Any]]:
     q = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,requested_by")
+        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,payment_doc_key,requested_by")
         .order("created_at", desc=True)
     )
     if status:
@@ -316,7 +316,7 @@ def get_expense_by_id_for_approver(expense_id: str) -> Optional[Dict[str, Any]]:
     res = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,requested_by")
+        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,payment_doc_key,requested_by")
         .eq("id", expense_id)
         .single()
         .execute()


### PR DESCRIPTION
## Summary
- Include `payment_doc_key` in expense listings and approver detail queries so pages can generate payment document URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75aa78000832e8d50493243c2b4ad