### PR TITLE
Show warning when expense lacks supporting document

### DIFF
--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -18,7 +18,6 @@ from f_read import (
     list_expenses_by_supplier_id,
     list_expenses_by_category,
     list_expenses_by_requester,
-    signed_url_for_receipt,
     signed_url_for_payment,
     _render_download,
 )
@@ -141,13 +140,18 @@ with tab2:
         )
 
         rec_key = exp.get("supporting_doc_key") or ""
-        rec_url = signed_url_for_receipt(rec_key, 600)
         pay_key = exp.get("payment_doc_key") or ""
-        pay_url = signed_url_for_payment(pay_key, 600)
         cols_files = st.columns(2)
         with cols_files[0]:
-            _render_download(rec_url, rec_key, "Documento de respaldo")
+            if rec_key:
+                sb = get_client()
+                out = sb.storage.from_("quotes").create_signed_url(rec_key, 600)
+                rec_url = (out or {}).get("signed_url")
+                _render_download(rec_url, rec_key, "Documento de respaldo")
+            else:
+                st.warning("No se encontró archivo")
         with cols_files[1]:
+            pay_url = signed_url_for_payment(pay_key, 600)
             _render_download(pay_url, pay_key, "Comprobante de pago")
 
         st.divider()
@@ -309,13 +313,18 @@ with tab3:
             f"**Creado:** {_fmt_dt(exp['created_at'])}"
         )
         rec_key = exp.get("supporting_doc_key") or ""
-        rec_url = signed_url_for_receipt(rec_key, 600)
         pay_key = exp.get("payment_doc_key") or ""
-        pay_url = signed_url_for_payment(pay_key, 600)
         cols_files = st.columns(2)
         with cols_files[0]:
-            _render_download(rec_url, rec_key, "Documento de respaldo")
+            if rec_key:
+                sb = get_client()
+                out = sb.storage.from_("quotes").create_signed_url(rec_key, 600)
+                rec_url = (out or {}).get("signed_url")
+                _render_download(rec_url, rec_key, "Documento de respaldo")
+            else:
+                st.warning("No se encontró archivo")
         with cols_files[1]:
+            pay_url = signed_url_for_payment(pay_key, 600)
             _render_download(pay_url, pay_key, "Comprobante de pago")
 
         st.divider()


### PR DESCRIPTION
## Summary
- Generate Supabase signed URL for supporting docs only when a supporting_doc_key exists
- Warn users when no supporting document is available

## Testing
- `python -m py_compile pages/aprobador.py pages/pagador.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75dd443f8832eb5dfaee0b4a910d3