### PR TITLE
feat: display message when payment doc missing

### DIFF
--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -19,7 +19,7 @@ from f_read import (
     list_expenses_by_category,
     list_expenses_by_requester,
     signed_url_for_receipt,
-    signed_url_for_payment,
+    payment_doc_url_for_expense,
     _render_download,
 )
 
@@ -142,13 +142,15 @@ with tab2:
 
         rec_key = exp.get("supporting_doc_key") or ""
         rec_url = signed_url_for_receipt(rec_key, 600)
-        pay_key = exp.get("payment_doc_key") or ""
-        pay_url = signed_url_for_payment(pay_key, 600)
+        pay_url, pay_key = payment_doc_url_for_expense(expense_id, 600)
         cols_files = st.columns(2)
         with cols_files[0]:
             _render_download(rec_url, rec_key, "Documento de respaldo")
         with cols_files[1]:
-            _render_download(pay_url, pay_key, "Comprobante de pago")
+            if pay_url:
+                _render_download(pay_url, pay_key or "", "Comprobante de pago")
+            else:
+                st.caption("No se encontró archivo")
 
         st.divider()
         st.subheader("Historial (logs)")
@@ -310,13 +312,15 @@ with tab3:
         )
         rec_key = exp.get("supporting_doc_key") or ""
         rec_url = signed_url_for_receipt(rec_key, 600)
-        pay_key = exp.get("payment_doc_key") or ""
-        pay_url = signed_url_for_payment(pay_key, 600)
+        pay_url, pay_key = payment_doc_url_for_expense(eid, 600)
         cols_files = st.columns(2)
         with cols_files[0]:
             _render_download(rec_url, rec_key, "Documento de respaldo")
         with cols_files[1]:
-            _render_download(pay_url, pay_key, "Comprobante de pago")
+            if pay_url:
+                _render_download(pay_url, pay_key or "", "Comprobante de pago")
+            else:
+                st.caption("No se encontró archivo")
 
         st.divider()
         logs = list_expense_logs(eid)


### PR DESCRIPTION
## Summary
- add helper to fetch `payment_doc_key` and sign URLs from `payments` bucket
- show "No se encontró archivo" when an expense lacks a payment document

## Testing
- `python -m py_compile f_read.py pages/pagador.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75dd52f34832e8212d2de2ccb9604