### PR TITLE
Use signed URL helpers for downloads

### DIFF
--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -132,8 +132,6 @@ with tab2:
     with left:
         rec_key = exp.get("supporting_doc_key") or ""
         pay_key = exp.get("payment_doc_key") or ""
-        rec_url = signed_url_for_receipt(rec_key, 600)
-        pay_url = signed_url_for_payment(pay_key, 600)
         details_md = (
             f"**Proveedor:** {exp['supplier_name']}  \n"
             f"**Descripción:** {exp.get('description','')}  \n"
@@ -146,9 +144,9 @@ with tab2:
         st.markdown(details_md)
         cols_files = st.columns(2)
         with cols_files[0]:
-            _render_download(rec_url, rec_key, "Documento de respaldo")
+            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
         with cols_files[1]:
-            _render_download(pay_url, pay_key, "Comprobante de pago")
+            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
 
         st.divider()
         st.subheader("Historial (logs)")
@@ -299,13 +297,11 @@ with tab3:
         )
         rec_key = exp.get("supporting_doc_key") or ""
         pay_key = exp.get("payment_doc_key") or ""
-        rec_url = signed_url_for_receipt(rec_key, 600)
-        pay_url = signed_url_for_payment(pay_key, 600)
         cols_files = st.columns(2)
         with cols_files[0]:
-            _render_download(rec_url, rec_key, "Documento de respaldo")
+            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
         with cols_files[1]:
-            _render_download(pay_url, pay_key, "Comprobante de pago")
+            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
 
         st.divider()
         logs = list_expense_logs(eid)

--- a/pages/lector.py
+++ b/pages/lector.py
@@ -212,11 +212,9 @@ with tab_detalle:
 
     st.divider()
     rec_key = row.get("supporting_doc_key") or ""
-    rec_url = signed_url_for_receipt(rec_key, 600)
     pay_key = row.get("payment_doc_key") or ""
-    pay_url = signed_url_for_payment(pay_key, 600)
     cols_files = st.columns(2)
     with cols_files[0]:
-        _render_download(rec_url, rec_key or "", "Documento de respaldo")
+        _render_download(rec_key or "", "Documento de respaldo", signed_url_for_receipt)
     with cols_files[1]:
-        _render_download(pay_url, pay_key or "", "Comprobante de pago")
+        _render_download(pay_key or "", "Comprobante de pago", signed_url_for_payment)

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -141,14 +141,12 @@ with tab2:
         )
 
         rec_key = exp.get("supporting_doc_key") or ""
-        rec_url = signed_url_for_receipt(rec_key, 600)
         pay_key = exp.get("payment_doc_key") or ""
-        pay_url = signed_url_for_payment(pay_key, 600)
         cols_files = st.columns(2)
         with cols_files[0]:
-            _render_download(rec_url, rec_key, "Documento de respaldo")
+            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
         with cols_files[1]:
-            _render_download(pay_url, pay_key, "Comprobante de pago")
+            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
 
         st.divider()
         st.subheader("Historial (logs)")
@@ -309,14 +307,12 @@ with tab3:
             f"**Creado:** {_fmt_dt(exp['created_at'])}"
         )
         rec_key = exp.get("supporting_doc_key") or ""
-        rec_url = signed_url_for_receipt(rec_key, 600)
         pay_key = exp.get("payment_doc_key") or ""
-        pay_url = signed_url_for_payment(pay_key, 600)
         cols_files = st.columns(2)
         with cols_files[0]:
-            _render_download(rec_url, rec_key, "Documento de respaldo")
+            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
         with cols_files[1]:
-            _render_download(pay_url, pay_key, "Comprobante de pago")
+            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
 
         st.divider()
         logs = list_expense_logs(eid)


### PR DESCRIPTION
## Summary
- refactor `_render_download` to compute signed URLs via helpers and warn when unavailable
- update aprobadors/pagador/lector pages to use new download rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75dd5edec832eb89349808625ef9d