### PR TITLE
fix: import missing receipt url helper

### DIFF
--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -9,6 +9,7 @@ from f_read import (
     get_expense_by_id_for_approver,    # -> full row for details
     list_expense_logs,
     list_expense_comments,
+    signed_url_for_receipt,
     signed_url_for_payment,
     list_suppliers,
     list_categories_from_expenses,


### PR DESCRIPTION
## Summary
- fix NameError on approver page by importing signed_url_for_receipt

## Testing
- `python -m py_compile pages/aprobador.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b761da90f8832eb98fa72ff0463a71