### PR TITLE
Use link buttons for document access

### DIFF
--- a/f_read.py
+++ b/f_read.py
@@ -3,46 +3,30 @@ from typing import List, Dict, Any, Optional, Tuple, Set, Iterable, Callable
 from f_auth import get_client
 from collections import defaultdict
 import datetime as dt
-import os
 import uuid
-import requests
 import pandas as pd
 
 # --------------------------
 # Utilidades de UI
 # --------------------------
-def _render_download(key: str, label: str, url_fn: Callable[[str, int], Optional[str]]) -> None:
-    """Renderiza un botón de descarga para un archivo en Supabase Storage.
+def _render_download(
+    key: str, label: str, url_fn: Callable[[str, int], Optional[str]]
+) -> None:
+    """Renderiza un botón que abre el archivo en una nueva pestaña.
 
     ``url_fn`` debe ser una función que retorne una URL firmada para ``key``.
-    El botón de descarga solo estará habilitado si la URL firmada no está vacía.
-    En caso contrario se mostrará un mensaje de advertencia y el botón permanecerá deshabilitado.
+    El botón permanecerá deshabilitado si la URL firmada está vacía.
     """
 
     dl_key = f"dl-{label}-{uuid.uuid4().hex}"
-    url = url_fn(key, 600)
-    if url:
-        try:
-            resp = requests.get(url, timeout=10)
-            resp.raise_for_status()
-            st.download_button(
-                label,
-                resp.content,
-                file_name=os.path.basename(key) if key else label.replace(" ", "_"),
-                key=dl_key,
-                width="content",
-            )
-        except Exception as e:  # pragma: no cover - UI feedback
-            st.caption(f"No se pudo descargar {label}: {e}")
-    else:
-        st.download_button(
-            label,
-            b"",
-            file_name=os.path.basename(key) if key else label.replace(" ", "_"),
-            key=dl_key,
-            disabled=True,
-            width="content",
-        )
+    url = url_fn(key, 600) if key else None
+    st.link_button(
+        label,
+        url or "#",
+        key=dl_key,
+        use_container_width=True,
+        disabled=not bool(url),
+    )
 
 # ==========================
 # ==== AUTH AND ADMIN ======

--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -130,8 +130,8 @@ with tab2:
 
     # ---- Left: details, logs, comments
     with left:
-        rec_key = exp.get("supporting_doc_key") or ""
-        pay_key = exp.get("payment_doc_key") or ""
+        rec_key = exp.get("supporting_doc_key")
+        pay_key = exp.get("payment_doc_key")
         details_md = (
             f"**Proveedor:** {exp['supplier_name']}  \n"
             f"**Descripción:** {exp.get('description','')}  \n"
@@ -297,8 +297,8 @@ with tab3:
             f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
             f"**Creado:** {_fmt_dt(exp['created_at'])}"
         )
-        rec_key = exp.get("supporting_doc_key") or ""
-        pay_key = exp.get("payment_doc_key") or ""
+        rec_key = exp.get("supporting_doc_key")
+        pay_key = exp.get("payment_doc_key")
         cols_files = st.columns(2)
         with cols_files[0]:
 

--- a/pages/lector.py
+++ b/pages/lector.py
@@ -211,10 +211,10 @@ with tab_detalle:
     )
 
     st.divider()
-    rec_key = row.get("supporting_doc_key") or ""
-    pay_key = row.get("payment_doc_key") or ""
+    rec_key = row.get("supporting_doc_key")
+    pay_key = row.get("payment_doc_key")
     cols_files = st.columns(2)
     with cols_files[0]:
-        _render_download(rec_key or "", "Documento de respaldo", signed_url_for_receipt)
+        _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
     with cols_files[1]:
-        _render_download(pay_key or "", "Comprobante de pago", signed_url_for_payment)
+        _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -141,9 +141,9 @@ with tab2:
             f"**Solicitante:** {exp.get('requested_by_email','')}"
         )
 
-        rec_key = exp.get("supporting_doc_key") or ""
+        rec_key = exp.get("supporting_doc_key")
 
-        pay_key = exp.get("payment_doc_key") or ""
+        pay_key = exp.get("payment_doc_key")
         cols_files = st.columns(2)
         with cols_files[0]:
             _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
@@ -309,9 +309,9 @@ with tab3:
             f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
             f"**Creado:** {_fmt_dt(exp['created_at'])}"
         )
-        rec_key = exp.get("supporting_doc_key") or ""
+        rec_key = exp.get("supporting_doc_key")
 
-        pay_key = exp.get("payment_doc_key") or ""
+        pay_key = exp.get("payment_doc_key")
         cols_files = st.columns(2)
         with cols_files[0]:
             _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -1,11 +1,9 @@
 # pages/solicitante.py
 # Solicitudes: crear gasto, ver "Mis solicitudes", y "Detalles y actualizar"
 
-import os
 import uuid
 from pathlib import Path
 from decimal import Decimal
-import requests
 import streamlit as st
 import pandas as pd
 
@@ -202,59 +200,25 @@ with tab_detalle:
 )
 
     # Enlaces rápidos a archivos
-    rec_key = exp.get("supporting_doc_key") or ""
-    pay_key = exp.get("payment_doc_key") or ""
+    rec_key = exp.get("supporting_doc_key")
+    pay_key = exp.get("payment_doc_key")
     rec_url = signed_url_for_receipt(rec_key, 600)
     pay_url = signed_url_for_payment(pay_key, 600)
     colf1, colf2 = st.columns(2)
     with colf1:
-        if rec_url:
-            st.link_button("Ver recibo", rec_url, use_container_width=True)
-            try:
-                resp = requests.get(rec_url, timeout=10)
-                resp.raise_for_status()
-                st.download_button(
-                    "Descargar recibo",
-                    resp.content,
-                    file_name=os.path.basename(rec_key) if rec_key else "recibo",
-                    use_container_width=True,
-                    key=f"dl-recibo-{uuid.uuid4().hex}",
-                )
-            except Exception as e:
-                st.caption(f"No se pudo descargar el recibo: {e}")
-        else:
-            st.download_button(
-                "Descargar recibo",
-                b"",
-                file_name="recibo",
-                use_container_width=True,
-                disabled=True,
-                key=f"dl-recibo-{uuid.uuid4().hex}",
-            )
+        st.link_button(
+            "Ver recibo",
+            rec_url or "#",
+            use_container_width=True,
+            disabled=not bool(rec_url),
+        )
     with colf2:
-        if pay_url:
-            st.link_button("Ver comprobante de pago", pay_url, use_container_width=True)
-            try:
-                resp = requests.get(pay_url, timeout=10)
-                resp.raise_for_status()
-                st.download_button(
-                    "Descargar comprobante",
-                    resp.content,
-                    file_name=os.path.basename(pay_key) if pay_key else "comprobante",
-                    use_container_width=True,
-                    key=f"dl-comprobante-{uuid.uuid4().hex}",
-                )
-            except Exception as e:
-                st.caption(f"No se pudo descargar el comprobante: {e}")
-        else:
-            st.download_button(
-                "Descargar comprobante",
-                b"",
-                file_name="comprobante",
-                use_container_width=True,
-                disabled=True,
-                key=f"dl-comprobante-{uuid.uuid4().hex}",
-            )
+        st.link_button(
+            "Ver comprobante de pago",
+            pay_url or "#",
+            use_container_width=True,
+            disabled=not bool(pay_url),
+        )
 
     st.divider()
 


### PR DESCRIPTION
## Summary
- replace download helper with link-based version
- open supporting and payment documents with link buttons across approver, payer, and viewer pages
- simplify requester page to only show links for receipts and payment proofs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b769a06b64832ea9a6785761a124cb