### PR TITLE
Refactor comments and logs

### DIFF
--- a/f_cud.py
+++ b/f_cud.py
@@ -103,15 +103,14 @@ def remove_role(user_id: str, role: str) -> None:
         .execute()
     )
 
-def create_expense_log(expense_id: str, actor_id: str, action: str, message: str) -> None:
-    """Inserta un registro en ``expense_logs`` usando el nuevo campo ``message``."""
-    if not (expense_id and actor_id and action and (message or "").strip()):
+def create_expense_log(expense_id: str, actor_id: str, message: str) -> None:
+    """Inserta un registro en ``expense_logs`` con un ``message`` obligatorio."""
+    if not (expense_id and actor_id and (message or "").strip()):
         raise ValueError("Faltan datos para crear el log.")
     sb = get_client()
     payload = {
         "expense_id": expense_id,
         "actor_id": actor_id,
-        "action": action,
         "message": message.strip(),
     }
     sb.schema("public").table("expense_logs").insert(payload).execute()
@@ -153,32 +152,25 @@ def create_expense(
 
     if expense_id:
         try:
-            msg = (
-                f"create: supplier={supplier_id}, amount={round(float(amount), 2)}, "
-                f"category={category}"
-            )
-            if description:
-                msg += f", description={description}"
             create_expense_log(
                 expense_id=expense_id,
                 actor_id=requested_by,
-                action="create",
-                message=msg,
+                message="Solicitud creada",
             )
         except Exception:
             pass
 
     return expense_id
 
-def add_expense_comment(expense_id: str, actor_id: str, text: str) -> None:
-    """Guarda un comentario para la solicitud sin generar un nuevo log."""
-    if not (expense_id and actor_id and (text or "").strip()):
+def add_expense_comment(expense_id: str, created_by: str, message: str) -> None:
+    """Inserta un comentario en ``expense_comments``."""
+    if not (expense_id and created_by and (message or "").strip()):
         raise ValueError("Faltan datos para comentar.")
     sb = get_client()
     payload = {
         "expense_id": expense_id,
-        "author_id": actor_id,
-        "text": text.strip(),
+        "created_by": created_by,
+        "message": message.strip(),
     }
     sb.schema("public").table("expense_comments").insert(payload).execute()
 
@@ -190,24 +182,38 @@ VALID_FOR_APPROVER = {"solicitado", "aprobado", "rechazado"}  # 'pagado' is for 
 
 def update_expense_status(expense_id: str, actor_id: str, new_status: str, comment: Optional[str] = None) -> None:
     """
-    Cambia estado a 'solicitado'/'aprobado'/'rechazado' y agrega un log.
-    Si el estado es 'aprobado' o 'rechazado', también establece approved_by = actor_id.
+    Cambia estado y agrega un log simple. Si ``comment`` se provee, se guarda como
+    comentario aparte.
     """
     ns = (new_status or "").strip().lower()
     if ns not in VALID_FOR_APPROVER:
         raise ValueError("Estado inválido para aprobador.")
 
     sb = get_client()
+    # obtener estado anterior para el mensaje del log
+    res = (
+        sb.schema("public")
+        .table("expenses")
+        .select("status")
+        .eq("id", expense_id)
+        .limit(1)
+        .execute()
+    )
+    prev_status = (res.data or [{}])[0].get("status")
+
     update = {"status": ns}
     if ns in ("aprobado", "rechazado"):
         update["approved_by"] = actor_id
 
     sb.schema("public").table("expenses").update(update).eq("id", expense_id).execute()
 
-    msg = f"status -> {ns}"
-    if comment:
-        msg += f"; {comment}"
-    create_expense_log(expense_id, actor_id, action="update", message=msg)
+    create_expense_log(
+        expense_id,
+        actor_id,
+        message=f"Solicitud actualizada de {prev_status} a {ns}",
+    )
+    if comment and comment.strip():
+        add_expense_comment(expense_id, actor_id, comment.strip())
 
 def mark_expense_as_paid(
     expense_id: str,
@@ -229,8 +235,7 @@ def mark_expense_as_paid(
         {"status": "pagado", "payment_doc_key": payment_doc_key.strip(), "paid_by": actor_id}
     ).eq("id", expense_id).execute()
 
-    msg = f"status -> pagado; key={payment_doc_key}"
-    if comment:
-        msg += f"; {comment}"
-    create_expense_log(expense_id, actor_id, action="update", message=msg)
+    create_expense_log(expense_id, actor_id, message="Solicitud pagada")
+    if comment and comment.strip():
+        add_expense_comment(expense_id, actor_id, comment.strip())
 

--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -160,9 +160,8 @@ with tab2:
                 [
                     {
                         "Fecha": _fmt_dt(lg["created_at"]),
-                        "Acción": lg["action"],
                         "Actor": lg.get("actor_email", ""),
-                        "Detalles": lg.get("details_text", ""),
+                        "Mensaje": lg.get("message", ""),
                     }
                     for lg in logs
                 ]
@@ -179,7 +178,7 @@ with tab2:
                     {
                         "Fecha": _fmt_dt(c["created_at"]),
                         "Autor": c.get("actor_email", ""),
-                        "Comentario": c["text"],
+                        "Comentario": c["message"],
                     }
                     for c in comments
                 ]
@@ -310,7 +309,7 @@ with tab3:
         logs = list_expense_logs(eid)
         if logs:
             log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details_text", "")} for l in logs]
+                [{"Fecha": _fmt_dt(l["created_at"]), "Actor": l.get("actor_email",""), "Mensaje": l.get("message","")} for l in logs]
             )
             st.subheader("Historial (logs)")
             st.dataframe(log_df, use_container_width=True, hide_index=True)
@@ -318,7 +317,7 @@ with tab3:
         comments = list_expense_comments(eid)
         if comments:
             com_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["text"]} for c in comments]
+                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["message"]} for c in comments]
             )
             st.subheader("Comentarios")
             st.dataframe(com_df, use_container_width=True, hide_index=True)

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -156,7 +156,7 @@ with tab2:
         logs = list_expense_logs(expense_id)
         if logs:
             log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details_text", "")} for l in logs]
+                [{"Fecha": _fmt_dt(l["created_at"]), "Actor": l.get("actor_email",""), "Mensaje": l.get("message", "")} for l in logs]
             )
             st.dataframe(log_df, use_container_width=True, hide_index=True)
         else:
@@ -166,7 +166,7 @@ with tab2:
         comments = list_expense_comments(expense_id)
         if comments:
             com_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["text"]} for c in comments]
+                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["message"]} for c in comments]
             )
             st.dataframe(com_df, use_container_width=True, hide_index=True)
         else:
@@ -327,7 +327,7 @@ with tab3:
         logs = list_expense_logs(eid)
         if logs:
             log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Acción": l["action"], "Actor": l.get("actor_email",""), "Detalles": l.get("details_text", "")} for l in logs]
+                [{"Fecha": _fmt_dt(l["created_at"]), "Actor": l.get("actor_email",""), "Mensaje": l.get("message", "")} for l in logs]
             )
             st.subheader("Historial (logs)")
             st.dataframe(log_df, use_container_width=True, hide_index=True)
@@ -335,7 +335,7 @@ with tab3:
         comments = list_expense_comments(eid)
         if comments:
             com_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["text"]} for c in comments]
+                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["message"]} for c in comments]
             )
             st.subheader("Comentarios")
             st.dataframe(com_df, use_container_width=True, hide_index=True)

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -153,20 +153,26 @@ with tab_mias:
             url = signed_url_for_receipt(key or "", expires=300)
             return f"[Documento]({url})" if url else ""
 
+        def _fmt_fecha(s: str) -> str:
+            try:
+                return pd.to_datetime(s).strftime("%Y-%m-%d")
+            except Exception:
+                return s
+
         df = pd.DataFrame(
-    [
-        {
-            "Fecha": r["created_at"],
-            "Proveedor": r["supplier_name"],
-            "Monto": f"{r['amount']:.2f}",
-            "Categoría": r["category"],
-            "Descripción": r.get("description") or "",
-            "Estado": r["status"],
-            "Recibo": _signed_link(r.get("supporting_doc_key")),
-        }
-        for r in rows
-    ]
-)
+            [
+                {
+                    "Fecha Creado": _fmt_fecha(r["created_at"]),
+                    "Proveedor": r["supplier_name"],
+                    "Monto": f"{r['amount']:.2f}",
+                    "Categoría": r["category"],
+                    "Descripción": r.get("description") or "",
+                    "Estado": r["status"],
+                    "Recibo": _signed_link(r.get("supporting_doc_key")),
+                }
+                for r in rows
+            ]
+        )
         st.dataframe(df, use_container_width=True, hide_index=True)
 
 # ==========================
@@ -200,7 +206,7 @@ with tab_detalle:
         f"**Categoría:** {exp['category']}  \n"
         f"**Descripción:** {exp.get('description','')}  \n"
         f"**Estado:** {exp['status']}  \n"
-        f"**Fecha:** {exp['created_at']}"
+        f"**Fecha Creado:** {pd.to_datetime(exp['created_at']).strftime('%Y-%m-%d')}"
 )
 
     # Enlaces rápidos a archivos
@@ -258,7 +264,7 @@ with tab_detalle:
                 {
                     "Fecha": _fmt_dt(c["created_at"]),
                     "Autor": c.get("actor_email", ""),
-                    "Comentario": c["text"],
+                    "Comentario": c["message"],
                 }
                 for c in comentarios
             ]
@@ -277,9 +283,8 @@ with tab_detalle:
             [
                 {
                     "Fecha": _fmt_dt(lg["created_at"]),
-                    "Acción": lg["action"],
                     "Actor": lg.get("actor_email", ""),
-                    "Detalles": lg.get("details_text", ""),
+                    "Mensaje": lg.get("message", ""),
                 }
                 for lg in logs
             ]


### PR DESCRIPTION
## Summary
- show date-only `Fecha Creado` columns in solicitante views
- route comments to new `expense_comments` table with helper
- simplify log API and UI to single `message`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb474d7b04832e8fa5a0a968e59ef8