### PR TITLE
Reset expense selection after updates

### DIFF
--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -118,7 +118,14 @@ with tab2:
         : r["id"]
         for r in rows
     }
-    sel_label = st.selectbox("Selecciona una solicitud", list(opts.keys()))
+    sel_label = st.selectbox(
+        "Selecciona una solicitud",
+        [""] + list(opts.keys()),
+        index=0,
+        key="aprobador_sel",
+    )
+    if not sel_label:
+        st.stop()
     expense_id = opts[sel_label]
 
     exp = get_expense_by_id_for_approver(expense_id)
@@ -195,7 +202,7 @@ with tab2:
             options=estados_actualizables,
             index=estados_actualizables.index(exp["status"]) if exp["status"] in estados_actualizables else 0,
         )
-        comment = st.text_area("Comentario (opcional)")
+        comment = st.text_area("Comentario (opcional)", key="aprobador_comment")
 
         if st.button("Guardar cambios", type="primary", use_container_width=True):
             try:
@@ -206,6 +213,8 @@ with tab2:
                     # Cambia estado (y opcionalmente agrega comentario en el log)
                     update_expense_status(expense_id, user_id, new_status, comment or None)
                 st.success("Actualización guardada.")
+                st.session_state.aprobador_sel = ""
+                st.session_state.aprobador_comment = ""
                 st.rerun()
             except Exception as e:
                 st.error(f"No se pudo actualizar: {e}")

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -120,7 +120,14 @@ with tab2:
         : r["id"]
         for r in rows
     }
-    sel_label = st.selectbox("Selecciona una solicitud", list(opts.keys()))
+    sel_label = st.selectbox(
+        "Selecciona una solicitud",
+        [""] + list(opts.keys()),
+        index=0,
+        key="pagador_sel",
+    )
+    if not sel_label:
+        st.stop()
     expense_id = opts[sel_label]
 
     exp = get_expense_by_id_for_approver(expense_id)
@@ -194,7 +201,7 @@ with tab2:
             "Comprobante de pago (obligatorio si marcas 'Pagado')",
             type=["pdf", "png", "jpg", "jpeg", "webp"],
         )
-        comment = st.text_area("Comentario (opcional)")
+        comment = st.text_area("Comentario (opcional)", key="pagador_comment")
 
         if st.button("Guardar cambios", type="primary", use_container_width=True):
             try:
@@ -202,6 +209,8 @@ with tab2:
                 if new_status == exp["status"] and (comment or "").strip() and not pay_file:
                     add_expense_comment(expense_id, user_id, comment.strip())
                     st.success("Comentario agregado.")
+                    st.session_state.pagador_sel = ""
+                    st.session_state.pagador_comment = ""
                     st.rerun()
 
                 # Marcar como pagado → requiere archivo
@@ -229,6 +238,8 @@ with tab2:
                         comment=(comment or "").strip() or None,
                     )
                     st.success("Solicitud marcada como pagada.")
+                    st.session_state.pagador_sel = ""
+                    st.session_state.pagador_comment = ""
                     st.rerun()
 
                 # Cambiar de pagado → aprobado (raro) o simplemente de aprobado sin archivo
@@ -238,6 +249,8 @@ with tab2:
                     if (comment or "").strip():
                         add_expense_comment(expense_id, user_id, comment.strip())
                         st.success("Comentario agregado.")
+                        st.session_state.pagador_sel = ""
+                        st.session_state.pagador_comment = ""
                         st.rerun()
                     else:
                         st.info("No hay cambios que guardar.")

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -190,7 +190,14 @@ with tab_detalle:
         f"{m['created_at']} — {m['supplier_name']} — {m['amount']:.2f} — {m['status']}": m["id"]
         for m in mis
     }
-    sel_label = st.selectbox("Selecciona una solicitud", list(opts.keys()))
+    sel_label = st.selectbox(
+        "Selecciona una solicitud",
+        [""] + list(opts.keys()),
+        index=0,
+        key="solic_detalle_sel",
+    )
+    if not sel_label:
+        st.stop()
     sel_id = opts[sel_label]
 
     exp = get_my_expense(user_id, sel_id)
@@ -234,7 +241,11 @@ with tab_detalle:
     # Agregar comentario
     st.write("**Agregar comentario**")
     with st.form("form_comentario", clear_on_submit=True):
-        txt = st.text_area("Comentario", placeholder="Escribe tu comentario…")
+        txt = st.text_area(
+            "Comentario",
+            placeholder="Escribe tu comentario…",
+            key="solic_detalle_comment",
+        )
         if st.form_submit_button("Guardar comentario"):
             if not txt or not txt.strip():
                 st.error("Escribe un comentario.")
@@ -242,6 +253,8 @@ with tab_detalle:
                 try:
                     add_expense_comment(sel_id, user_id, txt.strip())
                     st.success("Comentario agregado.")
+                    st.session_state.solic_detalle_sel = ""
+                    st.session_state.solic_detalle_comment = ""
                     st.rerun()
                 except Exception as e:
                     st.error(f"No se pudo guardar el comentario: {e}")


### PR DESCRIPTION
## Summary
- Add blank default option in expense selectors for approver, payer, and requester pages
- Clear selection and comment fields after saving changes to ensure fresh state

## Testing
- `python -m py_compile pages/aprobador.py pages/pagador.py pages/solicitante.py`


------
https://chatgpt.com/codex/tasks/task_e_68befb4ed97c832eb8b27ecbfc123fcd