### PR TITLE
fix file uploader session state handling

### DIFF
--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -48,8 +48,6 @@ with tab_nueva:
         st.session_state["descripcion"] = ""
     if "comentario" not in st.session_state:
         st.session_state["comentario"] = ""
-    if "archivo" not in st.session_state:
-        st.session_state["archivo"] = None
 
     suppliers = list_suppliers()
     if not suppliers:
@@ -152,7 +150,7 @@ with tab_nueva:
                 st.session_state.monto = 0.0
                 st.session_state.descripcion = ""
                 st.session_state.comentario = ""
-                st.session_state.archivo = None
+                st.session_state.pop("archivo", None)
                 st.session_state.categoria = ""
 
                 st.rerun()


### PR DESCRIPTION
## Summary
- avoid manually assigning session state to file upload widget
- clear file uploader safely after submitting

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf02547ccc832e9665dca71ed809d8