### PR TITLE
Handle Streamlit session state reset in expense pages

### DIFF
--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -94,6 +94,11 @@ with tab1:
 with tab2:
     st.write("**Detalles y actualizar**")
 
+    if st.session_state.get("aprobador_reset"):
+        st.session_state.aprobador_sel = ""
+        st.session_state.aprobador_comment = ""
+        st.session_state.aprobador_reset = False
+
     # Horizontal radio to choose status to select from
     estado_sel = st.radio(
         "Elegir estado para seleccionar solicitudes:",
@@ -213,8 +218,7 @@ with tab2:
                     # Cambia estado (y opcionalmente agrega comentario en el log)
                     update_expense_status(expense_id, user_id, new_status, comment or None)
                 st.success("Actualización guardada.")
-                st.session_state.aprobador_sel = ""
-                st.session_state.aprobador_comment = ""
+                st.session_state.aprobador_reset = True
                 st.rerun()
             except Exception as e:
                 st.error(f"No se pudo actualizar: {e}")

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -102,6 +102,11 @@ with tab1:
 with tab2:
     st.write("**Detalles y marcar pagado**")
 
+    if st.session_state.get("pagador_reset"):
+        st.session_state.pagador_sel = ""
+        st.session_state.pagador_comment = ""
+        st.session_state.pagador_reset = False
+
     # Elegir estado desde el cual seleccionar (tiene sentido 'aprobado' y 'pagado')
     estado_sel = st.radio(
         "Elegir estado para seleccionar solicitudes:",
@@ -209,8 +214,7 @@ with tab2:
                 if new_status == exp["status"] and (comment or "").strip() and not pay_file:
                     add_expense_comment(expense_id, user_id, comment.strip())
                     st.success("Comentario agregado.")
-                    st.session_state.pagador_sel = ""
-                    st.session_state.pagador_comment = ""
+                    st.session_state.pagador_reset = True
                     st.rerun()
 
                 # Marcar como pagado → requiere archivo
@@ -238,8 +242,7 @@ with tab2:
                         comment=(comment or "").strip() or None,
                     )
                     st.success("Solicitud marcada como pagada.")
-                    st.session_state.pagador_sel = ""
-                    st.session_state.pagador_comment = ""
+                    st.session_state.pagador_reset = True
                     st.rerun()
 
                 # Cambiar de pagado → aprobado (raro) o simplemente de aprobado sin archivo
@@ -249,8 +252,7 @@ with tab2:
                     if (comment or "").strip():
                         add_expense_comment(expense_id, user_id, comment.strip())
                         st.success("Comentario agregado.")
-                        st.session_state.pagador_sel = ""
-                        st.session_state.pagador_comment = ""
+                        st.session_state.pagador_reset = True
                         st.rerun()
                     else:
                         st.info("No hay cambios que guardar.")

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -224,6 +224,11 @@ with tab_mias:
 with tab_detalle:
     st.write("**Detalles y actualización de una solicitud**")
 
+    if st.session_state.get("solic_detalle_reset"):
+        st.session_state.solic_detalle_sel = ""
+        st.session_state.solic_detalle_comment = ""
+        st.session_state.solic_detalle_reset = False
+
     mis = list_my_expenses(user_id, status=None)
     if not mis:
         st.caption("Aún no tienes solicitudes.")
@@ -297,8 +302,7 @@ with tab_detalle:
                 try:
                     add_expense_comment(sel_id, user_id, txt.strip())
                     st.success("Comentario agregado.")
-                    st.session_state.solic_detalle_sel = ""
-                    st.session_state.solic_detalle_comment = ""
+                    st.session_state.solic_detalle_reset = True
                     st.rerun()
                 except Exception as e:
                     st.error(f"No se pudo guardar el comentario: {e}")


### PR DESCRIPTION
## Summary
- avoid direct mutation of `st.session_state` after widget creation in payer and requester pages
- reset selection and comment via flag before rendering widgets to prevent modification errors

## Testing
- `python -m py_compile pages/aprobador.py pages/pagador.py pages/solicitante.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf0599e73c832e94d5a6e5ea366dd9