### PR TITLE
Fix file uploader session state error on solicitante page

### DIFF
--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -46,7 +46,7 @@ with tab_nueva:
         st.session_state["monto"] = 0.0
         st.session_state["descripcion"] = ""
         st.session_state["comentario"] = ""
-        st.session_state["archivo"] = None
+        st.session_state.pop("archivo", None)
         st.session_state["categoria"] = ""
 
     # Estado inicial para widgets
@@ -58,8 +58,6 @@ with tab_nueva:
         st.session_state["descripcion"] = ""
     if "comentario" not in st.session_state:
         st.session_state["comentario"] = ""
-    if "archivo" not in st.session_state:
-        st.session_state["archivo"] = None
     if "categoria" not in st.session_state:
         st.session_state["categoria"] = ""
 


### PR DESCRIPTION
## Summary
- avoid Streamlit session state assignment for `archivo` file uploader by popping key instead
- remove default session state assignment for file uploader

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf5947629c832eadc5ef93cb92f817