### PR TITLE
Show supplier history in expense detail views

### DIFF
--- a/f_read.py
+++ b/f_read.py
@@ -286,7 +286,7 @@ def list_expenses_for_status(status: Optional[str]) -> List[Dict[str, Any]]:
     q = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,payment_doc_key,requested_by")
+        .select("id,supplier_id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,payment_doc_key,requested_by")
         .order("created_at", desc=True)
     )
     if status:
@@ -303,7 +303,7 @@ def get_expense_by_id_for_approver(expense_id: str) -> Optional[Dict[str, Any]]:
     res = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,payment_doc_key,requested_by")
+        .select("id,supplier_id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,payment_doc_key,requested_by")
         .eq("id", expense_id)
         .single()
         .execute()

--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -138,7 +138,7 @@ with tab2:
         st.error("No se encontró la solicitud seleccionada.")
         st.stop()
 
-    left, right = st.columns([2, 1])
+    left, mid, right = st.columns([2, 2, 1])
 
     # ---- Left: details, logs, comments
     with left:
@@ -196,6 +196,29 @@ with tab2:
                 ]
             )
             st.dataframe(com_df, use_container_width=True, hide_index=True)
+
+    # ---- Middle: supplier history
+    with mid:
+        st.write("**Historial del proveedor**")
+        sup_id = exp.get("supplier_id")
+        hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
+        if hist_rows:
+            hist_df = pd.DataFrame(
+                [
+                    {
+                        "Descripción": r.get("description", "") or "",
+                        "Monto": f"{r['amount']:.2f}",
+                        "Categoría": r["category"],
+                        "Estado": r["status"],
+                        "Solicitante": r.get("requested_by_email", ""),
+                        "Creado": _fmt_dt(r["created_at"]),
+                    }
+                    for r in hist_rows
+                ]
+            )
+            st.dataframe(hist_df, use_container_width=True, hide_index=True)
+        else:
+            st.caption("Sin historial.")
 
     # ---- Right: update status + add comment
     with right:

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -140,7 +140,7 @@ with tab2:
         st.error("No se encontró la solicitud seleccionada.")
         st.stop()
 
-    left, right = st.columns([2, 1])
+    left, mid, right = st.columns([2, 2, 1])
 
     # ---- Izquierda: detalles + docs + logs + comentarios
     with left:
@@ -184,6 +184,29 @@ with tab2:
             st.dataframe(com_df, use_container_width=True, hide_index=True)
         else:
             st.caption("No hay comentarios.")
+
+    # ---- Medio: historial del proveedor
+    with mid:
+        st.write("**Historial del proveedor**")
+        sup_id = exp.get("supplier_id")
+        hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
+        if hist_rows:
+            hist_df = pd.DataFrame(
+                [
+                    {
+                        "Descripción": r.get("description", "") or "",
+                        "Monto": f"{r['amount']:.2f}",
+                        "Categoría": r["category"],
+                        "Estado": r["status"],
+                        "Solicitante": r.get("requested_by_email", ""),
+                        "Creado": _fmt_dt(r["created_at"]),
+                    }
+                    for r in hist_rows
+                ]
+            )
+            st.dataframe(hist_df, use_container_width=True, hide_index=True)
+        else:
+            st.caption("Sin historial.")
 
     # ---- Derecha: marcar pagado / comentario
     with right:


### PR DESCRIPTION
## Summary
- include supplier id when fetching expense details
- display supplier expense history alongside details for approvers
- display supplier expense history alongside details for payers

## Testing
- `python -m py_compile f_read.py pages/aprobador.py pages/pagador.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf5d3252e0832e9f3339acc2acd01d