### PR TITLE
Add reimbursement fields and personas management

### DIFF
--- a/f_cud.py
+++ b/f_cud.py
@@ -87,6 +87,16 @@ def create_category(name: str) -> None:
     sb = get_client()
     sb.schema("public").table("categories").insert({"name": nm}).execute()
 
+
+# ------------- Personas -------------
+
+def create_person(name: str) -> None:
+    nm = (name or "").strip()
+    if not nm:
+        raise ValueError("El nombre es obligatorio.")
+    sb = get_client()
+    sb.schema("public").table("people").insert({"name": nm}).execute()
+
 def assign_role(user_id: str, role: str) -> None:
     """
     Grant a single role (Spanish enum string) to the user.
@@ -144,6 +154,8 @@ def create_expense(
     category: str,
     supporting_doc_key: str,
     description: Optional[str] = None,   # <--- NEW
+    reimbursement: bool = False,
+    reimbursement_person: Optional[str] = None,
 ) -> Optional[str]:
     """
     Crea un expense (status 'solicitado') con descripción opcional.
@@ -151,6 +163,9 @@ def create_expense(
     raíz del bucket de Storage (p.ej. ``"uuid.pdf"``); ya no incluye una ruta
     de carpeta.
     """
+    if reimbursement and not (reimbursement_person or "").strip():
+        raise ValueError("Debes seleccionar la persona del reembolso.")
+
     sb = get_client()
     payload = {
         "requested_by": requested_by,
@@ -158,6 +173,8 @@ def create_expense(
         "amount": round(float(amount), 2),
         "category": category,
         "supporting_doc_key": (supporting_doc_key or "").strip(),
+        "reimbursement": bool(reimbursement),
+        "reimbursement_person": (reimbursement_person or None),
     }
     if description:
         payload["description"] = description

--- a/f_read.py
+++ b/f_read.py
@@ -105,6 +105,13 @@ def list_categories() -> List[str]:
     res = sb.schema("public").table("categories").select("name").order("name").execute()
     return [r["name"] for r in (res.data or [])]
 
+
+@st.cache_data(ttl=60, show_spinner=False)
+def list_people() -> List[str]:
+    sb = get_client()
+    res = sb.schema("public").table("people").select("name").order("name").execute()
+    return [r["name"] for r in (res.data or [])]
+
 def get_user_id_by_email(email: str) -> Optional[str]:
     """Get public.users.id by email (case-insensitive)."""
     sb = get_client()

--- a/pages/administrador.py
+++ b/pages/administrador.py
@@ -7,7 +7,7 @@ import streamlit as st
 import pandas as pd
 from supabase import create_client
 from f_auth import require_administrador, current_user, get_client
-from f_read import get_all_users, list_suppliers, list_categories
+from f_read import get_all_users, list_suppliers, list_categories, list_people
 from f_cud import (
     assign_role,
     remove_role,
@@ -15,6 +15,7 @@ from f_cud import (
     create_supplier,
     update_user_password,
     create_category,
+    create_person,
 )
 
 st.set_page_config(page_icon="🛡️", layout="wide")
@@ -40,12 +41,13 @@ def get_admin_client():
 
 ADMIN_CLIENT = get_admin_client()
 
-tab_crear, tab_editar, tab_pass, tab_prov, tab_cats = st.tabs([
+tab_crear, tab_editar, tab_pass, tab_prov, tab_cats, tab_personas = st.tabs([
     "Crear usuario",
     "Editar usuario",
     "Actualizar contraseña",
     "Proveedores",
     "Categorías",
+    "Personas",
 ])
 
 # =======================
@@ -285,5 +287,44 @@ with tab_cats:
                     msg = str(e)
                     if "duplicate" in msg.lower() or "unique" in msg.lower():
                         st.warning("Esa categoría ya existe.")
+                    else:
+                        st.error(f"No se pudo agregar: {e}")
+
+# =======================
+# Tab 6: Personas
+# =======================
+with tab_personas:
+    st.subheader("Personas")
+
+    personas = list_people()
+    if personas:
+        st.dataframe(
+            pd.DataFrame({"Nombre": personas}),
+            use_container_width=True,
+            hide_index=True,
+        )
+    else:
+        st.caption("Aún no hay personas.")
+
+    st.markdown("### Agregar persona")
+    with st.form("form_add_person", clear_on_submit=True):
+        nombre = st.text_input("Nombre *").strip()
+        submitted = st.form_submit_button("Agregar")
+        if submitted:
+            if not nombre:
+                st.error("El nombre es obligatorio.")
+            else:
+                try:
+                    create_person(nombre)
+                    try:
+                        list_people.clear()
+                    except Exception:
+                        pass
+                    st.success("Persona agregada.")
+                    st.rerun()
+                except Exception as e:
+                    msg = str(e)
+                    if "duplicate" in msg.lower() or "unique" in msg.lower():
+                        st.warning("Esa persona ya existe.")
                     else:
                         st.error(f"No se pudo agregar: {e}")


### PR DESCRIPTION
## Summary
- add people reader and creator helpers
- support reimbursement fields on expenses
- enable solicitantes to specify reimbursement person
- allow admins to list and add personas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c049b6a618832eb7781100f5c2efb7