### PR TITLE
Show reimbursement info in detail views

### DIFF
--- a/f_read.py
+++ b/f_read.py
@@ -185,7 +185,10 @@ def list_my_expenses(user_id: str, status: Optional[str] = None) -> List[Dict[st
     q = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,status,supporting_doc_key,created_at,requested_by,description")  # <---
+        .select(
+            "id,supplier_name,amount,category,status,supporting_doc_key,created_at,"
+            "requested_by,description,reimbursement,reimbursement_person"
+        )
         .eq("requested_by", user_id)
         .order("created_at", desc=True)
     )
@@ -228,7 +231,10 @@ def get_my_expense(user_id: str, expense_id: str) -> Optional[Dict[str, Any]]:
     res = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,status,supporting_doc_key,payment_doc_key,created_at,requested_by,description")  # <---
+        .select(
+            "id,supplier_name,amount,category,status,supporting_doc_key,payment_doc_key,created_at,"
+            "requested_by,description,reimbursement,reimbursement_person"
+        )
         .eq("id", expense_id)
         .eq("requested_by", user_id)
         .single()
@@ -297,7 +303,7 @@ def list_expenses_for_status(status: Optional[str]) -> List[Dict[str, Any]]:
         .table("expenses")
         .select(
             "id,supplier_id,amount,category,description,status,created_at,"
-            "supporting_doc_key,payment_doc_key,requested_by,suppliers(name)"
+            "supporting_doc_key,payment_doc_key,requested_by,reimbursement,reimbursement_person,suppliers(name)"
         )
         .order("created_at", desc=True)
     )
@@ -321,7 +327,7 @@ def get_expense_by_id_for_approver(expense_id: str) -> Optional[Dict[str, Any]]:
         .table("expenses")
         .select(
             "id,supplier_id,amount,category,description,status,created_at,"
-            "supporting_doc_key,payment_doc_key,requested_by,suppliers(name)"
+            "supporting_doc_key,payment_doc_key,requested_by,reimbursement,reimbursement_person,suppliers(name)"
         )
 
         .eq("id", expense_id)
@@ -390,7 +396,10 @@ def list_expenses_by_category(category: str) -> List[Dict[str, Any]]:
     res = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,requested_by")
+        .select(
+            "id,supplier_name,amount,category,description,status,created_at,"
+            "supporting_doc_key,requested_by,reimbursement,reimbursement_person"
+        )
         .eq("category", category)
         .order("created_at", desc=True)
         .execute()
@@ -407,7 +416,10 @@ def list_expenses_by_requester(user_id: str) -> List[Dict[str, Any]]:
     res = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,requested_by")
+        .select(
+            "id,supplier_name,amount,category,description,status,created_at,"
+            "supporting_doc_key,requested_by,reimbursement,reimbursement_person"
+        )
         .eq("requested_by", user_id)
         .order("created_at", desc=True)
         .execute()
@@ -548,7 +560,11 @@ def list_paid_expenses_enriched(
     q = (
         sb.schema("public")
         .table("v_expenses_basic")
-        .select("id,supplier_name,amount,category,description,status,created_at,supporting_doc_key,payment_doc_key,requested_by,approved_by,paid_by")
+        .select(
+            "id,supplier_name,amount,category,description,status,created_at,"
+            "supporting_doc_key,payment_doc_key,requested_by,approved_by,paid_by,"
+            "reimbursement,reimbursement_person"
+        )
         .eq("status", "pagado")
         .order("created_at", desc=True)
     )

--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -151,8 +151,13 @@ with tab2:
             f"**Categoría:** {exp['category']}  \n"
             f"**Estado actual:** {exp['status']}  \n"
             f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
-            f"**Solicitante:** {exp.get('requested_by_email','')}"
+            f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+            f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
         )
+        if exp.get("reimbursement"):
+            details_md += (
+                f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
+            )
         st.markdown(details_md)
         cols_files = st.columns(2)
         with cols_files[0]:

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -144,15 +144,21 @@ with tab2:
 
     # ---- Izquierda: detalles + docs + logs + comentarios
     with left:
-        st.markdown(
+        detalles_md = (
             f"**Proveedor:** {exp['supplier_name']}  \n"
             f"**Descripción:** {exp.get('description','')}  \n"
             f"**Monto:** {exp['amount']:.2f}  \n"
             f"**Categoría:** {exp['category']}  \n"
             f"**Estado actual:** {exp['status']}  \n"
             f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
-            f"**Solicitante:** {exp.get('requested_by_email','')}"
+            f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+            f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
         )
+        if exp.get("reimbursement"):
+            detalles_md += (
+                f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
+            )
+        st.markdown(detalles_md)
 
         rec_key = exp.get("supporting_doc_key")
 

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -288,14 +288,20 @@ with tab_detalle:
         st.stop()
 
     # Encabezado de detalles
-    st.markdown(
+    detalles_md = (
         f"**Proveedor:** {exp['supplier_name']}  \n"
         f"**Monto:** {exp['amount']:.2f}  \n"
         f"**Categoría:** {exp['category']}  \n"
         f"**Descripción:** {exp.get('description','')}  \n"
         f"**Estado:** {exp['status']}  \n"
-        f"**Fecha Creado:** {pd.to_datetime(exp['created_at']).strftime('%Y-%m-%d')}"
-)
+        f"**Fecha Creado:** {pd.to_datetime(exp['created_at']).strftime('%Y-%m-%d')}  \n"
+        f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
+    )
+    if exp.get("reimbursement"):
+        detalles_md += (
+            f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
+        )
+    st.markdown(detalles_md)
 
     # Enlaces rápidos a archivos
     rec_key = exp.get("supporting_doc_key")


### PR DESCRIPTION
## Summary
- load reimbursement and reimbursement_person in expense readers
- display reimbursement lines in solicitante, aprobador, and pagador detail tabs

## Testing
- `python -m py_compile f_read.py pages/solicitante.py pages/aprobador.py pages/pagador.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a620a444832eb40f5ecd46711d9c