### PR TITLE
Permitir actualizar comprobante de pago desde la pestaña de detalles

### DIFF
--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -231,44 +231,69 @@ with tab2:
             if not hoy:
                 payment_date = st.date_input("Fecha de pago", value=date.today())
 
-        pay_file = st.file_uploader(
-            "Comprobante de pago (obligatorio si marcas 'Pagado')",
-            type=["pdf", "png", "jpg", "jpeg", "webp"],
-        )
+        has_payment_doc = bool(pay_key)
+        update_payment_doc = False
+        pay_file = None
+        if has_payment_doc:
+            update_payment_doc = st.checkbox("Actualizar comprobante de pago")
+            if update_payment_doc:
+                pay_file = st.file_uploader(
+                    "Nuevo comprobante de pago",
+                    type=["pdf", "png", "jpg", "jpeg", "webp"],
+                    key="pagador_payment_doc",
+                )
+        else:
+            pay_file = st.file_uploader(
+                "Comprobante de pago (obligatorio si marcas 'Pagado')",
+                type=["pdf", "png", "jpg", "jpeg", "webp"],
+                key="pagador_payment_doc",
+            )
         comment = st.text_area("Comentario (opcional)", key="pagador_comment")
 
         if st.button("Guardar cambios", type="primary", use_container_width=True):
             try:
+                trimmed_comment = (comment or "").strip()
+                requires_new_file = new_status == "pagado" and (not has_payment_doc or update_payment_doc)
+
+                if requires_new_file and not pay_file:
+                    st.error("Debes adjuntar un comprobante para marcar como pagado.")
+                    st.stop()
+
                 # Solo comentario
-                if new_status == exp["status"] and (comment or "").strip() and not pay_file:
-                    add_expense_comment(expense_id, user_id, comment.strip())
+                if (
+                    new_status == exp["status"]
+                    and trimmed_comment
+                    and not requires_new_file
+                ):
+                    add_expense_comment(expense_id, user_id, trimmed_comment)
                     st.success("Comentario agregado.")
                     st.session_state.pagador_reset = True
                     st.rerun()
 
                 # Marcar como pagado → requiere archivo
                 elif new_status == "pagado":
-                    if not pay_file:
-                        st.error("Debes adjuntar un comprobante para marcar como pagado.")
-                        st.stop()
+                    payment_doc_key = pay_key
 
-                    # Subir archivo al bucket 'payments' con un identificador único
-                    sb = get_client()
-                    bucket = "payments"
-                    file_id = uuid.uuid4().hex + Path(pay_file.name).suffix
-                    sb.storage.from_(bucket).upload(
-                        file_id,
-                        pay_file.getvalue(),
-                        {"content-type": pay_file.type},
-                    )
+                    if requires_new_file and pay_file:
+                        # Subir archivo al bucket 'payments' con un identificador único
+                        sb = get_client()
+                        bucket = "payments"
+                        file_id = uuid.uuid4().hex + Path(pay_file.name).suffix
+                        sb.storage.from_(bucket).upload(
+                            file_id,
+                            pay_file.getvalue(),
+                            {"content-type": pay_file.type},
+                        )
+
+                        payment_doc_key = file_id
 
                     # Actualizar estado + payment_doc_key y log
                     mark_expense_as_paid(
                         expense_id=expense_id,
                         actor_id=user_id,
-                        payment_doc_key=file_id,
+                        payment_doc_key=payment_doc_key,
                         payment_date=payment_date.strftime("%Y-%m-%d"),
-                        comment=(comment or "").strip() or None,
+                        comment=trimmed_comment or None,
                     )
                     st.success("Solicitud marcada como pagada.")
                     st.session_state.pagador_reset = True
@@ -278,8 +303,8 @@ with tab2:
                 else:
                     # Si baja a 'aprobado' no hay comprobante; si sube a 'pagado' ya lo tratamos arriba
                     # En este caso (aprobado) permitimos solo comentario adicional
-                    if (comment or "").strip():
-                        add_expense_comment(expense_id, user_id, comment.strip())
+                    if trimmed_comment:
+                        add_expense_comment(expense_id, user_id, trimmed_comment)
                         st.success("Comentario agregado.")
                         st.session_state.pagador_reset = True
                         st.rerun()


### PR DESCRIPTION
## Summary
- oculté el cargador de archivo cuando la solicitud ya tiene comprobante de pago y agregué un checkbox para habilitarlo si se desea actualizar
- reutilicé el comprobante existente cuando no se sube uno nuevo y obligué cargar archivo solo cuando es necesario para marcar como pagado

## Testing
- python -m compileall pages/pagador.py


------
https://chatgpt.com/codex/tasks/task_e_68cb2e56f2f8832e8674adeb46fa9cdc