### PR TITLE
Refactor pagador page into fragments

### DIFF
--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -38,6 +38,7 @@ user_id = me["id"]
 
 ESTADOS = ["solicitado", "aprobado", "rechazado", "pagado"]
 
+
 def _fmt_dt(s: str) -> str:
     try:
         return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
@@ -45,381 +46,493 @@ def _fmt_dt(s: str) -> str:
         return s
 
 
+def _expense_label(expense: dict) -> str:
+    """Texto consistente para identificar un gasto en selectores."""
+
+    return (
+        f"{expense['supplier_name']} — {expense.get('description','')} — "
+        f"{_fmt_dt(expense['created_at'])} — {expense.get('requested_by_email','')}"
+    )
+
+
 # ---------------------------------------------------
 # Tabs
 # ---------------------------------------------------
 tab1, tab2, tab3 = st.tabs(["Solicitudes", "Detalles y marcar pagado", "Historial"])
 
+st.session_state.setdefault("pagador_resumen_refresh_token", 0)
+st.session_state.setdefault("pagador_historial_refresh_token", 0)
+st.session_state.setdefault("pagador_resumen_estado", "aprobado")
+st.session_state.setdefault("pagador_estado_sel", "aprobado")
+st.session_state.setdefault("pagador_sel", "")
+st.session_state.setdefault("pagador_comment", "")
+st.session_state.setdefault("pagador_selected_expense_id", None)
+
 # ---------------------------------------------------
 # Tab 1 — Solicitudes
 # ---------------------------------------------------
 with tab1:
-    st.write("**Solicitudes**")
+    with st.fragment("pagador_resumen"):
+        st.write("**Solicitudes**")
 
-    all_rows = list_expenses_for_status(status=None)
+        _ = st.session_state.get("pagador_resumen_refresh_token")
+        all_rows = list_expenses_for_status(status=None) or []
 
-    # Métricas por estado
-    counts = {e: 0 for e in ESTADOS}
-    for r in all_rows:
-        if r["status"] in counts:
-            counts[r["status"]] += 1
-    cols = st.columns(len(ESTADOS))
-    for i, e in enumerate(ESTADOS):
-        cols[i].metric(e.capitalize(), counts[e])
+        # Métricas por estado
+        counts = {e: 0 for e in ESTADOS}
+        for r in all_rows:
+            if r["status"] in counts:
+                counts[r["status"]] += 1
+        cols = st.columns(len(ESTADOS))
+        for i, e in enumerate(ESTADOS):
+            cols[i].metric(e.capitalize(), counts[e])
 
-    st.divider()
+        st.divider()
 
-    # Filtro por estado (por defecto, 'aprobado' es el más relevante para Pagador)
-    default_index = 1  # "(todos)"=0, 'aprobado'=1 si armamos la lista dinámicamente
-    estados_opts = ["(todos)"] + ESTADOS
-    selected_status = st.selectbox(
-        "Filtrar por estado",
-        options=estados_opts,
-        index=estados_opts.index("aprobado") if "aprobado" in estados_opts else 0,
-    )
-    rows = all_rows if selected_status == "(todos)" else [r for r in all_rows if r["status"] == selected_status]
-
-    if not rows:
-        st.caption("No hay solicitudes para este filtro.")
-    else:
-        df = pd.DataFrame(
-            [
-                {
-                    "Solicitante": r.get("requested_by_email", ""),
-                    "Monto": f"{r['amount']:.2f}",
-                    "Descripción": r.get("description") or "",
-                    "Categoría": r["category"],
-                    "Proveedor": r["supplier_name"],
-                    "Creado": _fmt_dt(r["created_at"]),
-                }
-                for r in rows
-            ]
+        # Filtro por estado (por defecto, 'aprobado' es el más relevante para Pagador)
+        estados_opts = ["(todos)"] + ESTADOS
+        default_status = st.session_state.get("pagador_resumen_estado", "aprobado")
+        if default_status not in estados_opts:
+            default_status = estados_opts[0]
+        selected_status = st.selectbox(
+            "Filtrar por estado",
+            options=estados_opts,
+            index=estados_opts.index(default_status),
+            key="pagador_resumen_estado",
         )
-        st.dataframe(df, use_container_width=True, hide_index=True)
+        rows = (
+            all_rows
+            if selected_status == "(todos)"
+            else [r for r in all_rows if r["status"] == selected_status]
+        )
+
+        if not rows:
+            st.caption("No hay solicitudes para este filtro.")
+        else:
+            df = pd.DataFrame(
+                [
+                    {
+                        "Solicitante": r.get("requested_by_email", ""),
+                        "Monto": f"{r['amount']:.2f}",
+                        "Descripción": r.get("description") or "",
+                        "Categoría": r["category"],
+                        "Proveedor": r["supplier_name"],
+                        "Creado": _fmt_dt(r["created_at"]),
+                    }
+                    for r in rows
+                ]
+            )
+            st.dataframe(df, use_container_width=True, hide_index=True)
 
 # ---------------------------------------------------
 # Tab 2 — Detalles y marcar pagado
 # ---------------------------------------------------
 with tab2:
-    st.write("**Detalles y marcar pagado**")
+    with st.fragment("pagador_detalle"):
+        st.write("**Detalles y marcar pagado**")
 
-    if st.session_state.get("pagador_reset"):
-        st.session_state.pagador_sel = ""
-        st.session_state.pagador_comment = ""
-        st.session_state.pagador_use_receipt = False
-        st.session_state.pagador_selected_expense_id = None
-        st.session_state.pagador_reset = False
-
-    # Elegir estado desde el cual seleccionar (tiene sentido 'aprobado' y 'pagado')
-    estado_sel = st.radio(
-        "Elegir estado para seleccionar solicitudes:",
-        options=["aprobado", "pagado", "solicitado", "rechazado"],
-        horizontal=True,
-        index=0,
-    )
-    rows = list_expenses_for_status(status=estado_sel)
-    if not rows:
-        st.caption("No hay solicitudes en este estado.")
-        st.stop()
-
-    # Selector: "proveedor — descripcion — creado — solicitante"
-    opts = {
-        f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['created_at'])} — {r.get('requested_by_email','')}"
-        : r["id"]
-        for r in rows
-    }
-    sel_label = st.selectbox(
-        "Selecciona una solicitud",
-        [""] + list(opts.keys()),
-        index=0,
-        key="pagador_sel",
-    )
-    if not sel_label:
-        st.stop()
-    expense_id = opts[sel_label]
-
-    prev_selected = st.session_state.get("pagador_selected_expense_id")
-    if prev_selected != expense_id:
-        st.session_state.pagador_selected_expense_id = expense_id
-        st.session_state.pagador_use_receipt = False
-
-    exp = get_expense_by_id_for_approver(expense_id)
-    if not exp:
-        st.error("No se encontró la solicitud seleccionada.")
-        st.stop()
-
-    rec_key = exp.get("supporting_doc_key")
-    pay_key = exp.get("payment_doc_key")
-    left, mid, right = st.columns([2, 1, 3])
-
-    # ---- Izquierda: detalles + docs + logs + comentarios
-    with left:
-        detalles_md = (
-            f"**Proveedor:** {exp['supplier_name']}  \n"
-            f"**Descripción:** {exp.get('description','')}  \n"
-            f"**Monto:** {exp['amount']:.2f}  \n"
-            f"**Categoría:** {exp['category']}  \n"
-            f"**Estado actual:** {exp['status']}  \n"
-            f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
-            f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
-            f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
-        )
-        if exp.get("reimbursement"):
-            detalles_md += (
-                f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
-            )
-        st.markdown(detalles_md)
-
-        cols_files = st.columns(2)
-        with cols_files[0]:
-            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
-        with cols_files[1]:
-            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
-
-
-        st.divider()
-        st.write("**Historial (logs)**")
-        logs = list_expense_logs(expense_id)
-        if logs:
-            log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Actor": l.get("actor_email",""), "Mensaje": l.get("message", "")} for l in logs]
-            )
-            st.dataframe(log_df, use_container_width=True, hide_index=True)
-        else:
-            st.caption("Sin historial.")
-
-        st.write("**Comentarios**")
-        comments = list_expense_comments(expense_id)
-        if comments:
-            com_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["message"]} for c in comments]
-            )
-            st.dataframe(com_df, use_container_width=True, hide_index=True)
-        else:
-            st.caption("No hay comentarios.")
-
-    # ---- Medio: historial del proveedor
-    with right:
-        st.write("**Historial del proveedor**")
-        sup_id = exp.get("supplier_id")
-        hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
-        if hist_rows:
-            hist_df = pd.DataFrame(
-                [
-                    {
-                        "Descripción": r.get("description", "") or "",
-                        "Monto": f"{r['amount']:.2f}",
-                        "Categoría": r["category"],
-                        "Estado": r["status"],
-                        "Solicitante": r.get("requested_by_email", ""),
-                        "Creado": _fmt_dt(r["created_at"]),
-                    }
-                    for r in hist_rows
-                ]
-            )
-            st.dataframe(hist_df, use_container_width=True, hide_index=True)
-        else:
-            st.caption("Sin historial.")
-
-    # ---- Derecha: marcar pagado / comentario
-    with mid:
-        st.write("**Actualizar estado / marcar pagado**")
-
-        estados_pagador = ["aprobado", "pagado", "rechazado"]  # Pagador puede rechazar
-        new_status = st.selectbox(
-            "Nuevo estado",
-            options=estados_pagador,
-            index=estados_pagador.index(exp["status"]) if exp["status"] in estados_pagador else 0,
+        estado_options = ["aprobado", "pagado", "solicitado", "rechazado"]
+        st.session_state.setdefault("pagador_estado_sel", estado_options[0])
+        estado_sel = st.radio(
+            "Elegir estado para seleccionar solicitudes:",
+            options=estado_options,
+            horizontal=True,
+            key="pagador_estado_sel",
         )
 
-        existing_payment_date_raw = exp.get("payment_date")
-        existing_payment_date = None
-        if existing_payment_date_raw:
-            try:
-                existing_payment_date = pd.to_datetime(existing_payment_date_raw).date()
-            except Exception:
-                existing_payment_date = None
+        state_rows = list_expenses_for_status(status=estado_sel) or []
+        rows = list(state_rows)
+        selected_id = st.session_state.get("pagador_selected_expense_id")
+        if selected_id and all(r["id"] != selected_id for r in rows):
+            extra = get_expense_by_id_for_approver(selected_id)
+            if extra:
+                rows.append(extra)
 
-        payment_date = existing_payment_date or date.today()
-        if new_status == "pagado":
-            hoy = st.checkbox(
-                "fecha de pago hoy",
-                value=existing_payment_date is None,
-            )
-            if hoy:
-                payment_date = date.today()
+        labels = [""]
+        label_to_id = {}
+        for r in rows:
+            label = _expense_label(r)
+            if label not in label_to_id:
+                labels.append(label)
+                label_to_id[label] = r["id"]
+
+        if len(labels) == 1:
+            st.caption("No hay solicitudes en este estado.")
+
+        sel_label = st.selectbox(
+            "Selecciona una solicitud",
+            labels,
+            key="pagador_sel",
+        )
+
+        if sel_label:
+            expense_id = label_to_id.get(sel_label)
+            if not expense_id:
+                st.error("No se encontró la solicitud seleccionada.")
             else:
-                payment_date = st.date_input(
-                    "Fecha de pago",
-                    value=payment_date,
-                )
-        else:
-            payment_date = None
-        pay_file = st.file_uploader(
-            "Comprobante de pago (opcional)",
-            type=["pdf", "png", "jpg", "jpeg", "webp"],
-        )
-        comment = st.text_area("Comentario (opcional)", key="pagador_comment")
-
-        if st.button("Guardar cambios", type="primary", use_container_width=True):
-            try:
-                comment_clean = (comment or "").strip()
-                if new_status == "pagado":
-                    payment_doc_key = None
-                    if pay_file:
-                        sb = get_client()
-                        bucket = "payments"
-                        file_id = uuid.uuid4().hex + Path(pay_file.name).suffix
-                        sb.storage.from_(bucket).upload(
-                            file_id,
-                            pay_file.getvalue(),
-                            {"content-type": pay_file.type},
-                        )
-                        payment_doc_key = file_id
-
-                    payment_date_dt = payment_date or date.today()
-                    payment_date_changed = False
-                    if new_status != exp["status"]:
-                        payment_date_changed = True
-                    elif existing_payment_date:
-                        payment_date_changed = payment_date_dt != existing_payment_date
-                    else:
-                        payment_date_changed = True
-
-                    if new_status != exp["status"] or payment_doc_key or payment_date_changed:
-                        mark_expense_as_paid(
-                            expense_id=expense_id,
-                            actor_id=user_id,
-                            payment_doc_key=payment_doc_key,
-                            payment_date=payment_date_dt.strftime("%Y-%m-%d"),
-                            comment=comment_clean or None,
-                        )
-                        msg = "Solicitud marcada como pagada."
-                        if new_status == exp["status"]:
-                            msg = "Solicitud actualizada."
-                        st.success(msg)
-                        st.session_state.pagador_reset = True
-                        st.rerun()
-                    elif comment_clean:
-                        add_expense_comment(expense_id, user_id, comment_clean)
-                        st.success("Comentario agregado.")
-                        st.session_state.pagador_reset = True
-                        st.rerun()
-                    else:
-                        st.info("No hay cambios que guardar.")
+                st.session_state.pagador_selected_expense_id = expense_id
+                exp = get_expense_by_id_for_approver(expense_id)
+                if not exp:
+                    st.error("No se encontró la solicitud seleccionada.")
                 else:
-                    if pay_file:
-                        st.warning("El comprobante de pago solo se adjunta al marcar como pagado.")
-                    if comment_clean:
-                        add_expense_comment(expense_id, user_id, comment_clean)
-                        st.success("Comentario agregado.")
-                        st.session_state.pagador_reset = True
-                        st.rerun()
-                    else:
-                        st.info("No hay cambios que guardar.")
-            except Exception as e:
-                st.error(f"No se pudo actualizar: {e}")
+                    rec_key = exp.get("supporting_doc_key")
+                    pay_key = exp.get("payment_doc_key")
+                    left, mid, right = st.columns([2, 1, 3])
+
+                    # ---- Izquierda: detalles + docs + logs + comentarios
+                    with left:
+                        detalles_md = (
+                            f"**Proveedor:** {exp['supplier_name']}  \n"
+                            f"**Descripción:** {exp.get('description','')}  \n"
+                            f"**Monto:** {exp['amount']:.2f}  \n"
+                            f"**Categoría:** {exp['category']}  \n"
+                            f"**Estado actual:** {exp['status']}  \n"
+                            f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
+                            f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+                            f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
+                        )
+                        if exp.get("reimbursement"):
+                            detalles_md += (
+                                f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
+                            )
+                        st.markdown(detalles_md)
+
+                        cols_files = st.columns(2)
+                        with cols_files[0]:
+                            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
+                        with cols_files[1]:
+                            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
+
+                        st.divider()
+                        st.write("**Historial (logs)**")
+                        logs = list_expense_logs(expense_id)
+                        if logs:
+                            log_df = pd.DataFrame(
+                                [
+                                    {
+                                        "Fecha": _fmt_dt(l["created_at"]),
+                                        "Actor": l.get("actor_email", ""),
+                                        "Mensaje": l.get("message", ""),
+                                    }
+                                    for l in logs
+                                ]
+                            )
+                            st.dataframe(log_df, use_container_width=True, hide_index=True)
+                        else:
+                            st.caption("Sin historial.")
+
+                        st.write("**Comentarios**")
+                        comments = list_expense_comments(expense_id)
+                        if comments:
+                            com_df = pd.DataFrame(
+                                [
+                                    {
+                                        "Fecha": _fmt_dt(c["created_at"]),
+                                        "Autor": c.get("actor_email", ""),
+                                        "Comentario": c["message"],
+                                    }
+                                    for c in comments
+                                ]
+                            )
+                            st.dataframe(com_df, use_container_width=True, hide_index=True)
+                        else:
+                            st.caption("No hay comentarios.")
+
+                    # ---- Medio: historial del proveedor
+                    with right:
+                        st.write("**Historial del proveedor**")
+                        sup_id = exp.get("supplier_id")
+                        hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
+                        if hist_rows:
+                            hist_df = pd.DataFrame(
+                                [
+                                    {
+                                        "Descripción": r.get("description", "") or "",
+                                        "Monto": f"{r['amount']:.2f}",
+                                        "Categoría": r["category"],
+                                        "Estado": r["status"],
+                                        "Solicitante": r.get("requested_by_email", ""),
+                                        "Creado": _fmt_dt(r["created_at"]),
+                                    }
+                                    for r in hist_rows
+                                ]
+                            )
+                            st.dataframe(hist_df, use_container_width=True, hide_index=True)
+                        else:
+                            st.caption("Sin historial.")
+
+                    # ---- Derecha: marcar pagado / comentario
+                    with mid:
+                        st.write("**Actualizar estado / marcar pagado**")
+
+                        estados_pagador = ["aprobado", "pagado", "rechazado"]  # Pagador puede rechazar
+                        new_status = st.selectbox(
+                            "Nuevo estado",
+                            options=estados_pagador,
+                            index=estados_pagador.index(exp["status"]) if exp["status"] in estados_pagador else 0,
+                        )
+
+                        existing_payment_date_raw = exp.get("payment_date")
+                        existing_payment_date = None
+                        if existing_payment_date_raw:
+                            try:
+                                existing_payment_date = pd.to_datetime(existing_payment_date_raw).date()
+                            except Exception:
+                                existing_payment_date = None
+
+                        payment_date = existing_payment_date or date.today()
+                        if new_status == "pagado":
+                            hoy = st.checkbox(
+                                "fecha de pago hoy",
+                                value=existing_payment_date is None,
+                            )
+                            if hoy:
+                                payment_date = date.today()
+                            else:
+                                payment_date = st.date_input(
+                                    "Fecha de pago",
+                                    value=payment_date,
+                                )
+                        else:
+                            payment_date = None
+                        pay_file = st.file_uploader(
+                            "Comprobante de pago (opcional)",
+                            type=["pdf", "png", "jpg", "jpeg", "webp"],
+                        )
+                        comment = st.text_area("Comentario (opcional)", key="pagador_comment")
+
+                        if st.button("Guardar cambios", type="primary", use_container_width=True):
+                            try:
+                                comment_clean = (comment or "").strip()
+                                status_changed = new_status != exp["status"]
+                                triggered_refresh = False
+
+                                if new_status == "pagado":
+                                    payment_doc_key = None
+                                    if pay_file:
+                                        sb = get_client()
+                                        bucket = "payments"
+                                        file_id = uuid.uuid4().hex + Path(pay_file.name).suffix
+                                        sb.storage.from_(bucket).upload(
+                                            file_id,
+                                            pay_file.getvalue(),
+                                            {"content-type": pay_file.type},
+                                        )
+                                        payment_doc_key = file_id
+
+                                    payment_date_dt = payment_date or date.today()
+                                    payment_date_changed = False
+                                    if status_changed:
+                                        payment_date_changed = True
+                                    elif existing_payment_date:
+                                        payment_date_changed = payment_date_dt != existing_payment_date
+                                    else:
+                                        payment_date_changed = True
+
+                                    if status_changed or payment_doc_key or payment_date_changed:
+                                        mark_expense_as_paid(
+                                            expense_id=expense_id,
+                                            actor_id=user_id,
+                                            payment_doc_key=payment_doc_key,
+                                            payment_date=payment_date_dt.strftime("%Y-%m-%d"),
+                                            comment=comment_clean or None,
+                                        )
+                                        msg = "Solicitud marcada como pagada."
+                                        if not status_changed:
+                                            msg = "Solicitud actualizada."
+                                        st.success(msg)
+                                        triggered_refresh = True
+                                        if status_changed:
+                                            st.session_state.pagador_resumen_refresh_token += 1
+                                            st.session_state.pagador_historial_refresh_token += 1
+                                    elif comment_clean:
+                                        add_expense_comment(expense_id, user_id, comment_clean)
+                                        st.success("Comentario agregado.")
+                                        triggered_refresh = True
+                                    else:
+                                        st.info("No hay cambios que guardar.")
+                                else:
+                                    if pay_file:
+                                        st.warning("El comprobante de pago solo se adjunta al marcar como pagado.")
+                                    if comment_clean:
+                                        add_expense_comment(expense_id, user_id, comment_clean)
+                                        st.success("Comentario agregado.")
+                                        triggered_refresh = True
+                                    else:
+                                        st.info("No hay cambios que guardar.")
+
+                                if triggered_refresh:
+                                    st.session_state.pagador_comment = ""
+                                    st.session_state.pagador_estado_sel = new_status
+                                    st.session_state.pagador_sel = _expense_label(exp)
+                                    st.rerun(fragment="pagador_detalle")
+                            except Exception as e:
+                                st.error(f"No se pudo actualizar: {e}")
+        else:
+            st.session_state.pagador_selected_expense_id = None
 
 # ---------------------------------------------------
 # Tab 3 — Historial
 # ---------------------------------------------------
 with tab3:
-    st.write("**Historial**")
+    with st.fragment("pagador_historial"):
+        st.write("**Historial**")
 
-    modo = st.radio(
-        "Ver por:",
-        options=["Proveedores", "Categorías", "Solicitantes"],
-        horizontal=True,
-    )
+        _ = st.session_state.get("pagador_historial_refresh_token")
 
-    if modo == "Proveedores":
-        sups = list_suppliers()
-        if not sups:
-            st.caption("No hay proveedores.")
-            st.stop()
-        sup_map = {s["name"]: s["id"] for s in sups}
-        sel_sup_name = st.selectbox("Proveedor", list(sup_map.keys()))
-        rows = list_expenses_by_supplier_id(sup_map[sel_sup_name])
-
-    elif modo == "Categorías":
-        cats = list_categories()
-        if not cats:
-            st.caption("No hay categorías.")
-            st.stop()
-        sel_cat = st.selectbox("Categoría", cats)
-        rows = list_expenses_by_category(sel_cat)
-
-    else:  # "Solicitantes"
-        reqs = list_requesters_for_approver()
-        if not reqs:
-            st.caption("No hay solicitantes con gastos.")
-            st.stop()
-        req_map = {r["email"]: r["id"] for r in reqs}
-        sel_email = st.selectbox("Solicitante", list(req_map.keys()))
-        rows = list_expenses_by_requester(req_map[sel_email])
-
-    if not rows:
-        st.caption("No hay gastos para este filtro.")
-        st.stop()
-
-    df = pd.DataFrame(
-        [
-            {
-                "Proveedor": r["supplier_name"],
-                "Descripción": r.get("description", "") or "",
-                "Monto": f"{r['amount']:.2f}",
-                "Categoría": r["category"],
-                "Estado": r["status"],
-                "Solicitante": r.get("requested_by_email", ""),
-                "Creado": _fmt_dt(r["created_at"]),
-            }
-            for r in rows
-        ]
-    )
-    st.dataframe(df, use_container_width=True, hide_index=True)
-
-    opt_map = {
-        f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['created_at'])} — {r.get('requested_by_email','')}"
-        : r["id"]
-        for r in rows
-    }
-    sel_label = st.selectbox("Selecciona una solicitud para revisar", list(opt_map.keys()))
-    eid = opt_map[sel_label]
-
-    exp = get_expense_by_id_for_approver(eid)
-    if exp:
-        st.markdown(
-            f"**Proveedor:** {exp['supplier_name']}  \n"
-            f"**Descripción:** {exp.get('description','')}  \n"
-            f"**Monto:** {exp['amount']:.2f}  \n"
-            f"**Categoría:** {exp['category']}  \n"
-            f"**Estado:** {exp['status']}  \n"
-            f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
-            f"**Creado:** {_fmt_dt(exp['created_at'])}"
+        modo_opts = ["Proveedores", "Categorías", "Solicitantes"]
+        st.session_state.setdefault("pagador_historial_modo", modo_opts[0])
+        modo = st.radio(
+            "Ver por:",
+            options=modo_opts,
+            horizontal=True,
+            key="pagador_historial_modo",
         )
-        rec_key = exp.get("supporting_doc_key")
 
-        pay_key = exp.get("payment_doc_key")
-        cols_files = st.columns(2)
-        with cols_files[0]:
-            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
-        with cols_files[1]:
-            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
+        rows = []
+        has_options = True
 
+        if modo == "Proveedores":
+            sups = list_suppliers()
+            if not sups:
+                has_options = False
+                st.caption("No hay proveedores.")
+            else:
+                sup_names = [s["name"] for s in sups]
+                sup_map = {s["name"]: s["id"] for s in sups}
+                if st.session_state.get("pagador_historial_supplier") not in sup_map:
+                    st.session_state["pagador_historial_supplier"] = sup_names[0]
+                sel_sup_name = st.selectbox(
+                    "Proveedor",
+                    sup_names,
+                    key="pagador_historial_supplier",
+                )
+                rows = list_expenses_by_supplier_id(sup_map[sel_sup_name])
 
-        st.divider()
-        logs = list_expense_logs(eid)
-        if logs:
-            log_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(l["created_at"]), "Actor": l.get("actor_email",""), "Mensaje": l.get("message", "")} for l in logs]
-            )
-            st.write("**Historial (logs)**")
-            st.dataframe(log_df, use_container_width=True, hide_index=True)
+        elif modo == "Categorías":
+            cats = list_categories()
+            if not cats:
+                has_options = False
+                st.caption("No hay categorías.")
+            else:
+                if st.session_state.get("pagador_historial_category") not in cats:
+                    st.session_state["pagador_historial_category"] = cats[0]
+                sel_cat = st.selectbox(
+                    "Categoría",
+                    cats,
+                    key="pagador_historial_category",
+                )
+                rows = list_expenses_by_category(sel_cat)
 
-        comments = list_expense_comments(eid)
-        if comments:
-            com_df = pd.DataFrame(
-                [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["message"]} for c in comments]
-            )
-            st.write("**Comentarios**")
-            st.dataframe(com_df, use_container_width=True, hide_index=True)
+        else:  # "Solicitantes"
+            reqs = list_requesters_for_approver()
+            if not reqs:
+                has_options = False
+                st.caption("No hay solicitantes con gastos.")
+            else:
+                emails = [r["email"] for r in reqs]
+                req_map = {r["email"]: r["id"] for r in reqs}
+                if st.session_state.get("pagador_historial_requester") not in req_map:
+                    st.session_state["pagador_historial_requester"] = emails[0]
+                sel_email = st.selectbox(
+                    "Solicitante",
+                    emails,
+                    key="pagador_historial_requester",
+                )
+                rows = list_expenses_by_requester(req_map[sel_email])
+
+        if has_options:
+            if not rows:
+                st.caption("No hay gastos para este filtro.")
+            else:
+                df = pd.DataFrame(
+                    [
+                        {
+                            "Proveedor": r["supplier_name"],
+                            "Descripción": r.get("description", "") or "",
+                            "Monto": f"{r['amount']:.2f}",
+                            "Categoría": r["category"],
+                            "Estado": r["status"],
+                            "Solicitante": r.get("requested_by_email", ""),
+                            "Creado": _fmt_dt(r["created_at"]),
+                        }
+                        for r in rows
+                    ]
+                )
+                st.dataframe(df, use_container_width=True, hide_index=True)
+
+                label_to_id = {}
+                labels = []
+                for r in rows:
+                    label = _expense_label(r)
+                    label_to_id[label] = r["id"]
+                    labels.append(label)
+
+                if labels:
+                    current_hist_sel = st.session_state.get("pagador_historial_sel")
+                    if current_hist_sel not in label_to_id:
+                        st.session_state["pagador_historial_sel"] = labels[0]
+                    sel_label = st.selectbox(
+                        "Selecciona una solicitud para revisar",
+                        labels,
+                        key="pagador_historial_sel",
+                    )
+                    eid = label_to_id.get(sel_label)
+
+                    if eid:
+                        exp = get_expense_by_id_for_approver(eid)
+                        if exp:
+                            st.markdown(
+                                f"**Proveedor:** {exp['supplier_name']}  \n"
+                                f"**Descripción:** {exp.get('description','')}  \n"
+                                f"**Monto:** {exp['amount']:.2f}  \n"
+                                f"**Categoría:** {exp['category']}  \n"
+                                f"**Estado:** {exp['status']}  \n"
+                                f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+                                f"**Creado:** {_fmt_dt(exp['created_at'])}"
+                            )
+                            rec_key = exp.get("supporting_doc_key")
+
+                            pay_key = exp.get("payment_doc_key")
+                            cols_files = st.columns(2)
+                            with cols_files[0]:
+                                _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
+                            with cols_files[1]:
+                                _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
+
+                            st.divider()
+                            logs = list_expense_logs(eid)
+                            if logs:
+                                log_df = pd.DataFrame(
+                                    [
+                                        {
+                                            "Fecha": _fmt_dt(l["created_at"]),
+                                            "Actor": l.get("actor_email", ""),
+                                            "Mensaje": l.get("message", ""),
+                                        }
+                                        for l in logs
+                                    ]
+                                )
+                                st.write("**Historial (logs)**")
+                                st.dataframe(log_df, use_container_width=True, hide_index=True)
+
+                            comments = list_expense_comments(eid)
+                            if comments:
+                                com_df = pd.DataFrame(
+                                    [
+                                        {
+                                            "Fecha": _fmt_dt(c["created_at"]),
+                                            "Autor": c.get("actor_email", ""),
+                                            "Comentario": c["message"],
+                                        }
+                                        for c in comments
+                                    ]
+                                )
+                                st.write("**Comentarios**")
+                                st.dataframe(com_df, use_container_width=True, hide_index=True)
+                            else:
+                                st.caption("No hay comentarios.")
+                        else:
+                            st.warning("No se encontró la solicitud seleccionada.")
+                else:
+                    st.caption("No hay solicitudes para revisar.")


### PR DESCRIPTION
## Summary
- wrap each tab in `pages/pagador.py` with Streamlit fragments and reuse a shared expense label helper
- add session state defaults and refresh tokens so summary metrics and history respond to status updates
- refresh only the detail fragment after marking a payment while preserving user selections and clearing comment state

## Testing
- python -m compileall pages/pagador.py

------
https://chatgpt.com/codex/tasks/task_e_68cb30aaae94832e8e5721b4882542b7