### PR TITLE
Fix is_registered_email client call

### DIFF
--- a/f_read.py
+++ b/f_read.py
@@ -30,7 +30,7 @@ def _render_download(
 # ==========================
 
 def is_registered_email(email: str) -> bool:
-    sb = get_client(use_session=False)
+    sb = get_client()
     q = (
         sb.table("app_users")
         .select("email")


### PR DESCRIPTION
## Summary
- update `is_registered_email` to call `get_client()` without unsupported keyword arguments

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68cb35cd5ee4832e979e5fabbfbe2843