### PR TITLE
Update Streamlit fragments to decorator usage

### DIFF
--- a/pages/administrador.py
+++ b/pages/administrador.py
@@ -96,340 +96,377 @@ def consume_fragment_refresh(data_key: str, fragment_name: str, clear_fn=None) -
         flags.pop(data_key, None)
     st.session_state[REFRESH_FLAGS_KEY] = flags
 
+
+@st.fragment
+def admin_crear_fragment():
+    with st.form("crear_usuario_form", clear_on_submit=True):
+        email = st.text_input("Email *", placeholder="persona@empresa.com")
+        display_name = st.text_input("Nombre para mostrar (opcional)")
+
+        st.caption("Asigna uno o varios roles para este usuario:")
+        cols = st.columns(5)
+        role_checks = {}
+        for i, role in enumerate(ROLES_ES):
+            with cols[i % 5]:
+                role_checks[role] = st.checkbox(role, value=(role == "solicitante"))
+
+        allow_otp = st.checkbox("Agregar a la lista permitida (OTP)", value=True)
+
+        submitted = st.form_submit_button("Crear usuario")
+        if not submitted:
+            return
+
+        if not email:
+            st.error("El email es obligatorio.")
+            return
+
+        try:
+            sb_admin = ADMIN_CLIENT
+            sb_admin.auth.admin.create_user(
+                {
+                    "email": email,
+                    "email_confirm": True,
+                    "user_metadata": {"display_name": display_name} if display_name else {},
+                }
+            )
+
+            if allow_otp:
+                try:
+                    add_app_user(email)
+                except Exception as e:
+                    st.warning(
+                        f"Usuario creado, pero no se pudo agregar a OTP allowlist: {e}"
+                    )
+
+            sb = get_client()
+            uid = None
+            for _ in range(3):
+                row = (
+                    sb.schema("public")
+                    .table("users")
+                    .select("id,email")
+                    .ilike("email", email.strip())
+                    .limit(1)
+                    .execute()
+                ).data
+                if row:
+                    uid = row[0]["id"]
+                    break
+                time.sleep(0.5)
+
+            selected_roles = [r for r, v in role_checks.items() if v]
+            if uid and selected_roles:
+                for r in selected_roles:
+                    try:
+                        assign_role(uid, r)
+                    except Exception as e:
+                        st.warning(f"No se pudo asignar rol {r}: {e}")
+            elif not uid:
+                st.warning(
+                    "Usuario creado en Auth. Aún no aparece en public.users; "
+                    "refresca esta página en unos segundos para asignar roles."
+                )
+
+            try:
+                get_all_users.clear()
+            except Exception:
+                pass
+
+            mark_fragment_refresh(
+                "users",
+                [FRAGMENT_KEYS["editar"], FRAGMENT_KEYS["pass"]],
+            )
+
+            st.success(f"Usuario creado: {email}")
+            st.rerun(scope="fragment")
+        except Exception as e:
+            st.error(f"No se pudo crear el usuario: {e}")
+
+
+@st.fragment
+def admin_editar_fragment():
+    consume_fragment_refresh(
+        "users",
+        FRAGMENT_KEYS["editar"],
+        getattr(get_all_users, "clear", None),
+    )
+
+    users = get_all_users()
+    if not users:
+        st.info("Aún no hay usuarios.")
+        st.stop()
+
+    def _label(u: dict) -> str:
+        nom = (u.get("display_name") or "").strip()
+        return f"{u['email']} — {nom}" if nom else u["email"]
+
+    options = {_label(u): u for u in users}
+    selected_label = st.selectbox("Selecciona un usuario", list(options.keys()))
+    selected_user = options[selected_label] if selected_label else None
+
+    if not selected_user:
+        return
+
+    roles_set = set(selected_user.get("roles", []))
+    me = current_user()
+    my_id = me["id"] if me else None
+
+    st.caption("Marca/Desmarca para asignar o quitar roles:")
+    cols2 = st.columns(5)
+    role_boxes = {}
+    for i, role in enumerate(ROLES_ES):
+        with cols2[i % 5]:
+            role_boxes[role] = st.checkbox(
+                role,
+                value=(role in roles_set),
+                key=f"cb-{role}-{selected_user['id']}",
+            )
+
+    if not st.button("Guardar cambios"):
+        return
+
+    try:
+        desired = {r for r, v in role_boxes.items() if v}
+        current = roles_set
+
+        to_add = desired - current
+        to_remove = current - desired
+
+        if selected_user["id"] == my_id and "administrador" in to_remove:
+            st.warning("No puedes quitarte el rol 'administrador' a ti mismo.")
+            to_remove.discard("administrador")
+
+        for r in sorted(to_add):
+            assign_role(selected_user["id"], r)
+            st.success(f"Rol '{r}' asignado.")
+
+        for r in sorted(to_remove):
+            remove_role(selected_user["id"], r)
+            st.success(f"Rol '{r}' removido.")
+
+        try:
+            get_all_users.clear()
+        except Exception:
+            pass
+
+        mark_fragment_refresh("users", [FRAGMENT_KEYS["pass"]])
+
+        st.rerun(scope="fragment")
+    except Exception as e:
+        st.error(f"Error al guardar cambios: {e}")
+
+
+@st.fragment
+def admin_pass_fragment():
+    consume_fragment_refresh(
+        "users",
+        FRAGMENT_KEYS["pass"],
+        getattr(get_all_users, "clear", None),
+    )
+
+    users = get_all_users()
+    emails = [u["email"] for u in users]
+    if not emails:
+        st.info("Aún no hay usuarios.")
+        return
+
+    with st.form("password_form", clear_on_submit=True):
+        email = st.selectbox("Selecciona un usuario", emails)
+        new_pwd = st.text_input("Nueva contraseña", type="password")
+        submitted = st.form_submit_button("Actualizar")
+        if not submitted:
+            return
+
+        if not new_pwd:
+            st.error("La contraseña no puede estar vacía.")
+            return
+
+        try:
+            update_user_password(email, new_pwd)
+            st.success("Contraseña actualizada.")
+        except Exception as e:
+            st.error(f"No se pudo actualizar: {e}")
+
+
+@st.fragment
+def admin_prov_fragment():
+    consume_fragment_refresh(
+        "suppliers",
+        FRAGMENT_KEYS["prov"],
+        getattr(list_suppliers, "clear", None),
+    )
+    consume_fragment_refresh(
+        "categories",
+        FRAGMENT_KEYS["prov"],
+        getattr(list_categories, "clear", None),
+    )
+
+    st.subheader("Proveedores")
+
+    sups = list_suppliers()
+    if sups:
+        df = pd.DataFrame(
+            [{"Proveedor": s["name"], "Categoría": s.get("category", "")} for s in sups]
+        )
+        st.dataframe(df, use_container_width=True, hide_index=True)
+    else:
+        st.caption("Aún no hay proveedores.")
+
+    st.markdown("### Agregar proveedor")
+    cats = list_categories()
+    if not cats:
+        st.info("No hay categorías. Primero agrega categorías en la pestaña 'Categorías'.")
+
+    with st.form("form_add_supplier", clear_on_submit=True):
+        nombre = st.text_input("Nombre del proveedor *").strip()
+        categoria = st.selectbox("Categoría *", cats, disabled=not bool(cats))
+        submitted = st.form_submit_button("Crear", disabled=not bool(cats))
+        if not submitted:
+            return
+
+        try:
+            create_supplier(nombre, categoria)
+            try:
+                list_suppliers.clear()
+            except Exception:
+                pass
+            st.success("Proveedor creado.")
+            st.balloons()
+            st.rerun(scope="fragment")
+        except Exception as e:
+            msg = str(e).lower()
+            if "duplicate" in msg or "unique" in msg:
+                st.warning("Ese proveedor ya existe.")
+            else:
+                st.error(f"No se pudo crear el proveedor: {e}")
+
+
+@st.fragment
+def admin_cats_fragment():
+    consume_fragment_refresh(
+        "categories",
+        FRAGMENT_KEYS["cats"],
+        getattr(list_categories, "clear", None),
+    )
+
+    st.subheader("Categorías")
+
+    cats = list_categories()
+    if cats:
+        st.dataframe(
+            pd.DataFrame({"Categoría": cats}), use_container_width=True, hide_index=True
+        )
+    else:
+        st.caption("Aún no hay categorías.")
+
+    st.markdown("### Agregar categoría")
+    with st.form("form_add_category", clear_on_submit=True):
+        cat_name = st.text_input("Nombre de categoría *", placeholder="Ej. Software").strip()
+        submitted = st.form_submit_button("Agregar")
+        if not submitted:
+            return
+
+        if not cat_name:
+            st.error("El nombre es obligatorio.")
+            return
+
+        try:
+            create_category(cat_name)
+            try:
+                list_categories.clear()
+            except Exception:
+                pass
+            mark_fragment_refresh("categories", [FRAGMENT_KEYS["prov"]])
+            st.success("Categoría agregada.")
+            st.rerun(scope="fragment")
+        except Exception as e:
+            msg = str(e)
+            if "duplicate" in msg.lower() or "unique" in msg.lower():
+                st.warning("Esa categoría ya existe.")
+            else:
+                st.error(f"No se pudo agregar: {e}")
+
+
+@st.fragment
+def admin_personas_fragment():
+    consume_fragment_refresh(
+        "people",
+        FRAGMENT_KEYS["personas"],
+        getattr(list_people, "clear", None),
+    )
+
+    st.subheader("Personas")
+
+    personas = list_people()
+    if personas:
+        st.dataframe(
+            pd.DataFrame({"Nombre": personas}),
+            use_container_width=True,
+            hide_index=True,
+        )
+    else:
+        st.caption("Aún no hay personas.")
+
+    st.markdown("### Agregar persona")
+    with st.form("form_add_person", clear_on_submit=True):
+        nombre = st.text_input("Nombre *").strip()
+        submitted = st.form_submit_button("Agregar")
+        if not submitted:
+            return
+
+        if not nombre:
+            st.error("El nombre es obligatorio.")
+            return
+
+        try:
+            create_person(nombre)
+            try:
+                list_people.clear()
+            except Exception:
+                pass
+            st.success("Persona agregada.")
+            st.rerun(scope="fragment")
+        except Exception as e:
+            msg = str(e)
+            if "duplicate" in msg.lower() or "unique" in msg.lower():
+                st.warning("Esa persona ya existe.")
+            else:
+                st.error(f"No se pudo agregar: {e}")
+
+
 # =======================
 # Tab 1: Crear usuario
 # =======================
 with tab_crear:
-    with st.fragment(FRAGMENT_KEYS["crear"]):
-        with st.form("crear_usuario_form", clear_on_submit=True):
-            email = st.text_input("Email *", placeholder="persona@empresa.com")
-            display_name = st.text_input("Nombre para mostrar (opcional)")
-
-            st.caption("Asigna uno o varios roles para este usuario:")
-            cols = st.columns(5)
-            role_checks = {}
-            for i, role in enumerate(ROLES_ES):
-                with cols[i % 5]:
-                    role_checks[role] = st.checkbox(role, value=(role == "solicitante"))
-
-            allow_otp = st.checkbox("Agregar a la lista permitida (OTP)", value=True)
-
-            submitted = st.form_submit_button("Crear usuario")
-            if submitted:
-                if not email:
-                    st.error("El email es obligatorio.")
-                else:
-                    try:
-                        sb_admin = ADMIN_CLIENT
-                        # Crea el usuario en Auth (confirmado para permitir OTP inmediato).
-                        resp = sb_admin.auth.admin.create_user(
-                            {
-                                "email": email,
-                                "email_confirm": True,
-                                "user_metadata": {"display_name": display_name} if display_name else {},
-                            }
-                        )
-
-                        # (Opcional) Agregar a allowlist para el flujo OTP por email
-                        if allow_otp:
-                            try:
-                                add_app_user(email)
-                            except Exception as e:
-                                st.warning(
-                                    f"Usuario creado, pero no se pudo agregar a OTP allowlist: {e}"
-                                )
-
-                        # Intentar encontrar el id del espejo en public.users (puede tardar un segundo)
-                        sb = get_client()
-                        uid = None
-                        for _ in range(3):  # pequeño retry para esperar el trigger espejo
-                            row = (
-                                sb.schema("public")
-                                .table("users")
-                                .select("id,email")
-                                .ilike("email", email.strip())
-                                .limit(1)
-                                .execute()
-                            ).data
-                            if row:
-                                uid = row[0]["id"]
-                                break
-                            time.sleep(0.5)
-
-                        # Asignar roles si ya tenemos uid
-                        selected_roles = [r for r, v in role_checks.items() if v]
-                        if uid and selected_roles:
-                            for r in selected_roles:
-                                try:
-                                    assign_role(uid, r)
-                                except Exception as e:
-                                    st.warning(f"No se pudo asignar rol {r}: {e}")
-                        elif not uid:
-                            st.warning(
-                                "Usuario creado en Auth. Aún no aparece en public.users; "
-                                "refresca esta página en unos segundos para asignar roles."
-                            )
-
-                        # Limpiar cache para que aparezca en 'Editar usuario'
-                        try:
-                            get_all_users.clear()
-                        except Exception:
-                            pass
-
-                        mark_fragment_refresh(
-                            "users",
-                            [FRAGMENT_KEYS["editar"], FRAGMENT_KEYS["pass"]],
-                        )
-
-                        st.success(f"Usuario creado: {email}")
-                        st.rerun(fragment=FRAGMENT_KEYS["crear"])
-                    except Exception as e:
-                        st.error(f"No se pudo crear el usuario: {e}")
+    admin_crear_fragment()
 
 # =======================
 # Tab 2: Editar usuario
 # =======================
 with tab_editar:
-    with st.fragment(FRAGMENT_KEYS["editar"]):
-        consume_fragment_refresh(
-            "users",
-            FRAGMENT_KEYS["editar"],
-            getattr(get_all_users, "clear", None),
-        )
-
-        users = get_all_users()
-        if not users:
-            st.info("Aún no hay usuarios.")
-            st.stop()
-
-        # Opciones del selectbox: "email — nombre"
-        def _label(u: dict) -> str:
-            nom = (u.get("display_name") or "").strip()
-            return f"{u['email']} — {nom}" if nom else u["email"]
-
-        options = { _label(u): u for u in users }
-        selected_label = st.selectbox("Selecciona un usuario", list(options.keys()))
-        selected_user = options[selected_label] if selected_label else None
-
-        if selected_user:
-            roles_set = set(selected_user.get("roles", []))
-            me = current_user()
-            my_id = me["id"] if me else None
-
-            st.caption("Marca/Desmarca para asignar o quitar roles:")
-            cols2 = st.columns(5)
-            role_boxes = {}
-            for i, role in enumerate(ROLES_ES):
-                with cols2[i % 5]:
-                    role_boxes[role] = st.checkbox(
-                        role,
-                        value=(role in roles_set),
-                        key=f"cb-{role}-{selected_user['id']}"
-                    )
-
-            if st.button("Guardar cambios"):
-                try:
-                    # Aplicar diferencias
-                    desired = {r for r, v in role_boxes.items() if v}
-                    current = roles_set
-
-                    to_add = desired - current
-                    to_remove = current - desired
-
-                    # Evitar que un admin se quite a sí mismo el rol administrador
-                    if selected_user["id"] == my_id and "administrador" in to_remove:
-                        st.warning("No puedes quitarte el rol 'administrador' a ti mismo.")
-                        to_remove.discard("administrador")
-
-                    for r in sorted(to_add):
-                        assign_role(selected_user["id"], r)
-                        st.success(f"Rol '{r}' asignado.")
-
-                    for r in sorted(to_remove):
-                        remove_role(selected_user["id"], r)
-                        st.success(f"Rol '{r}' removido.")
-
-                    try:
-                        get_all_users.clear()
-                    except Exception:
-                        pass
-
-                    mark_fragment_refresh("users", [FRAGMENT_KEYS["pass"]])
-
-                    st.rerun(fragment=FRAGMENT_KEYS["editar"])
-                except Exception as e:
-                    st.error(f"Error al guardar cambios: {e}")
+    admin_editar_fragment()
 
 # =======================
 # Tab 3: Actualizar contraseña
 # =======================
 with tab_pass:
-    with st.fragment(FRAGMENT_KEYS["pass"]):
-        consume_fragment_refresh(
-            "users",
-            FRAGMENT_KEYS["pass"],
-            getattr(get_all_users, "clear", None),
-        )
-
-        users = get_all_users()
-        emails = [u["email"] for u in users]
-        if not emails:
-            st.info("Aún no hay usuarios.")
-        else:
-            with st.form("password_form", clear_on_submit=True):
-                email = st.selectbox("Selecciona un usuario", emails)
-                new_pwd = st.text_input("Nueva contraseña", type="password")
-                submitted = st.form_submit_button("Actualizar")
-                if submitted:
-                    if not new_pwd:
-                        st.error("La contraseña no puede estar vacía.")
-                    else:
-                        try:
-                            update_user_password(email, new_pwd)
-                            st.success("Contraseña actualizada.")
-                        except Exception as e:
-                            st.error(f"No se pudo actualizar: {e}")
+    admin_pass_fragment()
 
 # =======================
 # Tab 4: Proveedores
 # =======================
 with tab_prov:
-    with st.fragment(FRAGMENT_KEYS["prov"]):
-        consume_fragment_refresh(
-            "suppliers",
-            FRAGMENT_KEYS["prov"],
-            getattr(list_suppliers, "clear", None),
-        )
-        consume_fragment_refresh(
-            "categories",
-            FRAGMENT_KEYS["prov"],
-            getattr(list_categories, "clear", None),
-        )
-
-        st.subheader("Proveedores")
-
-        sups = list_suppliers()
-        if sups:
-            df = pd.DataFrame(
-                [{"Proveedor": s["name"], "Categoría": s.get("category", "")} for s in sups]
-            )
-            st.dataframe(df, use_container_width=True, hide_index=True)
-        else:
-            st.caption("Aún no hay proveedores.")
-
-        st.markdown("### Agregar proveedor")
-        cats = list_categories()
-        if not cats:
-            st.info("No hay categorías. Primero agrega categorías en la pestaña 'Categorías'.")
-
-        with st.form("form_add_supplier", clear_on_submit=True):
-            nombre = st.text_input("Nombre del proveedor *").strip()
-            categoria = st.selectbox("Categoría *", cats, disabled=not bool(cats))
-            submitted = st.form_submit_button("Crear", disabled=not bool(cats))
-            if submitted:
-                try:
-                    create_supplier(nombre, categoria)
-                    try:
-                        list_suppliers.clear()
-                    except Exception:
-                        pass
-                    st.success("Proveedor creado.")
-                    st.balloons()
-                    st.rerun(fragment=FRAGMENT_KEYS["prov"])
-                except Exception as e:
-                    msg = str(e).lower()
-                    if "duplicate" in msg or "unique" in msg:
-                        st.warning("Ese proveedor ya existe.")
-                    else:
-                        st.error(f"No se pudo crear el proveedor: {e}")
+    admin_prov_fragment()
 
 # =======================
 # Tab 5: Categorías
 # =======================
 with tab_cats:
-    with st.fragment(FRAGMENT_KEYS["cats"]):
-        consume_fragment_refresh(
-            "categories",
-            FRAGMENT_KEYS["cats"],
-            getattr(list_categories, "clear", None),
-        )
-
-        st.subheader("Categorías")
-
-        cats = list_categories()
-        if cats:
-            st.dataframe(
-                pd.DataFrame({"Categoría": cats}), use_container_width=True, hide_index=True
-            )
-        else:
-            st.caption("Aún no hay categorías.")
-
-        st.markdown("### Agregar categoría")
-        with st.form("form_add_category", clear_on_submit=True):
-            cat_name = st.text_input("Nombre de categoría *", placeholder="Ej. Software").strip()
-            submitted = st.form_submit_button("Agregar")
-            if submitted:
-                if not cat_name:
-                    st.error("El nombre es obligatorio.")
-                else:
-                    try:
-                        create_category(cat_name)
-                        try:
-                            list_categories.clear()
-                        except Exception:
-                            pass
-                        mark_fragment_refresh("categories", [FRAGMENT_KEYS["prov"]])
-                        st.success("Categoría agregada.")
-                        st.rerun(fragment=FRAGMENT_KEYS["cats"])
-                    except Exception as e:
-                        msg = str(e)
-                        if "duplicate" in msg.lower() or "unique" in msg.lower():
-                            st.warning("Esa categoría ya existe.")
-                        else:
-                            st.error(f"No se pudo agregar: {e}")
+    admin_cats_fragment()
 
 # =======================
 # Tab 6: Personas
 # =======================
 with tab_personas:
-    with st.fragment(FRAGMENT_KEYS["personas"]):
-        consume_fragment_refresh(
-            "people",
-            FRAGMENT_KEYS["personas"],
-            getattr(list_people, "clear", None),
-        )
+    admin_personas_fragment()
 
-        st.subheader("Personas")
-
-        personas = list_people()
-        if personas:
-            st.dataframe(
-                pd.DataFrame({"Nombre": personas}),
-                use_container_width=True,
-                hide_index=True,
-            )
-        else:
-            st.caption("Aún no hay personas.")
-
-        st.markdown("### Agregar persona")
-        with st.form("form_add_person", clear_on_submit=True):
-            nombre = st.text_input("Nombre *").strip()
-            submitted = st.form_submit_button("Agregar")
-            if submitted:
-                if not nombre:
-                    st.error("El nombre es obligatorio.")
-                else:
-                    try:
-                        create_person(nombre)
-                        try:
-                            list_people.clear()
-                        except Exception:
-                            pass
-                        st.success("Persona agregada.")
-                        st.rerun(fragment=FRAGMENT_KEYS["personas"])
-                    except Exception as e:
-                        msg = str(e)
-                        if "duplicate" in msg.lower() or "unique" in msg.lower():
-                            st.warning("Esa persona ya existe.")
-                        else:
-                            st.error(f"No se pudo agregar: {e}")

--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -3,7 +3,7 @@
 
 import pandas as pd
 import streamlit as st
-from f_auth import require_aprobador, current_user, get_client
+from f_auth import require_aprobador, current_user
 from f_read import (
     list_expenses_for_status,          # -> for metrics/table in Tab 1
     get_expense_by_id_for_approver,    # -> full row for details
@@ -36,340 +36,351 @@ ESTADOS = ["solicitado", "aprobado", "rechazado", "pagado"]
 st.session_state.setdefault("aprobador_resumen_needs_refresh", False)
 st.session_state.setdefault("aprobador_historial_needs_refresh", False)
 
-# ---------------------------------------------------
-# Tab 1 — Solicitudes
-# ---------------------------------------------------
 tab1, tab2, tab3 = st.tabs(["Solicitudes", "Detalles y actualizar", "Historial"])
 
-with tab1:
-    with st.fragment("aprobador_resumen"):
-        if st.session_state.get("aprobador_resumen_needs_refresh"):
-            st.session_state.aprobador_resumen_needs_refresh = False
-            st.rerun(fragment="aprobador_resumen")
 
-        st.write("**Solicitudes**")
+@st.fragment
+def aprobador_resumen_fragment():
+    if st.session_state.get("aprobador_resumen_needs_refresh"):
+        st.session_state.aprobador_resumen_needs_refresh = False
+        st.rerun(scope="fragment")
 
-        # Pull once for metrics (all statuses) and reuse
-        all_rows = list_expenses_for_status(status=None)
+    st.write("**Solicitudes**")
 
-        # Metrics row
-        counts = {e: 0 for e in ESTADOS}
-        for r in all_rows:
-            if r["status"] in counts:
-                counts[r["status"]] += 1
-        cols = st.columns(len(ESTADOS))
-        for i, e in enumerate(ESTADOS):
-            cols[i].metric(e.capitalize(), counts[e])
+    all_rows = list_expenses_for_status(status=None)
+
+    counts = {e: 0 for e in ESTADOS}
+    for r in all_rows:
+        if r["status"] in counts:
+            counts[r["status"]] += 1
+    cols = st.columns(len(ESTADOS))
+    for i, e in enumerate(ESTADOS):
+        cols[i].metric(e.capitalize(), counts[e])
+
+    st.divider()
+
+    selected_status = st.selectbox(
+        "Filtrar por estado",
+        options=ESTADOS,
+        index=0,
+    )
+    rows = [r for r in all_rows if r["status"] == selected_status]
+
+    if not rows:
+        st.caption("No hay solicitudes para este filtro.")
+        return
+
+    def _fmt_dt(s: str) -> str:
+        try:
+            return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return s
+
+    df = pd.DataFrame(
+        [
+            {
+                "Solicitante": r.get("requested_by_email", ""),
+                "Monto": f"{r['amount']:.2f}",
+                "Descripción": r.get("description") or "",
+                "Categoría": r["category"],
+                "Proveedor": r["supplier_name"],
+                "Creado": _fmt_dt(r["created_at"]),
+            }
+            for r in rows
+        ]
+    )
+    st.dataframe(df, use_container_width=True, hide_index=True)
+
+
+@st.fragment
+def aprobador_detalle_fragment():
+    st.write("**Detalles y actualizar**")
+
+    estado_sel = st.radio(
+        "Elegir estado para seleccionar solicitudes:",
+        options=ESTADOS,
+        horizontal=True,
+    )
+
+    rows = list_expenses_for_status(status=estado_sel)
+    if not rows:
+        st.caption("No hay solicitudes en este estado.")
+        st.stop()
+
+    def _fmt_dt(s: str) -> str:
+        try:
+            return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return s
+
+    opts = {
+        f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['created_at'])} — {r.get('requested_by_email','')}"
+        : r["id"]
+        for r in rows
+    }
+    sel_label = st.selectbox(
+        "Selecciona una solicitud",
+        [""] + list(opts.keys()),
+        index=0,
+        key="aprobador_sel",
+    )
+    if not sel_label:
+        st.stop()
+    expense_id = opts[sel_label]
+
+    exp = get_expense_by_id_for_approver(expense_id)
+    if not exp:
+        st.error("No se encontró la solicitud seleccionada.")
+        st.stop()
+
+    left, mid, right = st.columns([2, 1, 3])
+
+    with left:
+        rec_key = exp.get("supporting_doc_key")
+        pay_key = exp.get("payment_doc_key")
+        details_md = (
+            f"**Proveedor:** {exp['supplier_name']}  \n"
+            f"**Descripción:** {exp.get('description','')}  \n"
+            f"**Monto:** {exp['amount']:.2f}  \n"
+            f"**Categoría:** {exp['category']}  \n"
+            f"**Estado actual:** {exp['status']}  \n"
+            f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
+            f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+            f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
+        )
+        if exp.get("reimbursement"):
+            details_md += (
+                f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
+            )
+        st.markdown(details_md)
+        cols_files = st.columns(2)
+        with cols_files[0]:
+            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
+        with cols_files[1]:
+            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
 
         st.divider()
-
-        # Filter by status
-        selected_status = st.selectbox(
-            "Filtrar por estado",
-            options=ESTADOS,
-            index=0,
-        )
-        rows = [r for r in all_rows if r["status"] == selected_status]
-
-        if not rows:
-            st.caption("No hay solicitudes para este filtro.")
+        st.write("**Historial (logs)**")
+        logs = list_expense_logs(expense_id)
+        if not logs:
+            st.caption("Sin historial.")
         else:
-            # Build DataFrame with Spanish headers & formatted date
-            def _fmt_dt(s: str) -> str:
-                try:
-                    return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
-                except Exception:
-                    return s
-
-            df = pd.DataFrame(
+            log_df = pd.DataFrame(
                 [
                     {
-                        "Solicitante": r.get("requested_by_email", ""),
-                        "Monto": f"{r['amount']:.2f}",
-                        "Descripción": r.get("description") or "",
-                        "Categoría": r["category"],
-                        "Proveedor": r["supplier_name"],
-                        "Creado": _fmt_dt(r["created_at"]),
+                        "Fecha": _fmt_dt(lg["created_at"]),
+                        "Actor": lg.get("actor_email", ""),
+                        "Mensaje": lg.get("message", ""),
                     }
-                    for r in rows
+                    for lg in logs
                 ]
             )
-            st.dataframe(df, use_container_width=True, hide_index=True)
+            st.dataframe(log_df, use_container_width=True, hide_index=True)
 
-# ---------------------------------------------------
-# Tab 2 — Detalles y actualizar
-# ---------------------------------------------------
-with tab2:
-    with st.fragment("aprobador_detalle"):
-        st.write("**Detalles y actualizar**")
+        st.write("**Comentarios**")
+        comments = list_expense_comments(expense_id)
+        if not comments:
+            st.caption("No hay comentarios.")
+        else:
+            com_df = pd.DataFrame(
+                [
+                    {
+                        "Fecha": _fmt_dt(c["created_at"]),
+                        "Autor": c.get("actor_email", ""),
+                        "Comentario": c["message"],
+                    }
+                    for c in comments
+                ]
+            )
+            st.dataframe(com_df, use_container_width=True, hide_index=True)
 
-        # Horizontal radio to choose status to select from
-        estado_sel = st.radio(
-            "Elegir estado para seleccionar solicitudes:",
-            options=ESTADOS,
-            horizontal=True,
+    with right:
+        st.write("**Historial del proveedor**")
+        sup_id = exp.get("supplier_id")
+        hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
+        if hist_rows:
+            hist_df = pd.DataFrame(
+                [
+                    {
+                        "Descripción": r.get("description", "") or "",
+                        "Monto": f"{r['amount']:.2f}",
+                        "Categoría": r["category"],
+                        "Estado": r["status"],
+                        "Solicitante": r.get("requested_by_email", ""),
+                        "Creado": _fmt_dt(r["created_at"]),
+                    }
+                    for r in hist_rows
+                ]
+            )
+            st.dataframe(hist_df, use_container_width=True, hide_index=True)
+        else:
+            st.caption("Sin historial.")
+
+    with mid:
+        st.write("**Actualizar estado / agregar comentario**")
+        estados_actualizables = ["solicitado", "aprobado", "rechazado"]
+        new_status = st.selectbox(
+            "Nuevo estado",
+            options=estados_actualizables,
+            index=(
+                estados_actualizables.index(exp["status"])
+                if exp["status"] in estados_actualizables
+                else 0
+            ),
         )
+        comment = st.text_area("Comentario (opcional)", key="aprobador_comment")
 
-        rows = list_expenses_for_status(status=estado_sel)
-        if not rows:
-            st.caption("No hay solicitudes en este estado.")
-            st.stop()
-
-        # Build labels: "proveedor - descripcion - created_at - created_by"
-        def _fmt_dt(s: str) -> str:
+        if st.button("Guardar cambios", type="primary", use_container_width=True):
             try:
-                return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
-            except Exception:
-                return s
+                if new_status == exp["status"] and comment.strip():
+                    add_expense_comment(expense_id, user_id, comment.strip())
+                else:
+                    update_expense_status(expense_id, user_id, new_status, comment or None)
+                st.success("Actualización guardada.")
+                st.session_state.aprobador_comment = ""
+                st.session_state.aprobador_resumen_needs_refresh = True
+                st.session_state.aprobador_historial_needs_refresh = True
+                st.rerun(scope="fragment")
+            except Exception as e:
+                st.error(f"No se pudo actualizar: {e}")
 
-        opts = {
-            f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['created_at'])} — {r.get('requested_by_email','')}"
-            : r["id"]
+
+@st.fragment
+def aprobador_historial_fragment():
+    if st.session_state.get("aprobador_historial_needs_refresh"):
+        st.session_state.aprobador_historial_needs_refresh = False
+        st.rerun(scope="fragment")
+
+    st.write("**Historial**")
+
+    modo = st.radio(
+        "Ver por:",
+        options=["Proveedores", "Categorías", "Solicitantes"],
+        horizontal=True,
+    )
+
+    if modo == "Proveedores":
+        sups = list_suppliers()
+        if not sups:
+            st.caption("No hay proveedores.")
+            st.stop()
+        sup_map = {s["name"]: s["id"] for s in sups}
+        sel_sup_name = st.selectbox("Proveedor", list(sup_map.keys()))
+        rows = list_expenses_by_supplier_id(sup_map[sel_sup_name])
+
+    elif modo == "Categorías":
+        cats = list_categories()
+        if not cats:
+            st.caption("No hay categorías.")
+            st.stop()
+        sel_cat = st.selectbox("Categoría", cats)
+        rows = list_expenses_by_category(sel_cat)
+
+    else:
+        reqs = list_requesters_for_approver()
+        if not reqs:
+            st.caption("No hay solicitantes con gastos.")
+            st.stop()
+        req_map = {r["email"]: r["id"] for r in reqs}
+        sel_email = st.selectbox("Solicitante", list(req_map.keys()))
+        rows = list_expenses_by_requester(req_map[sel_email])
+
+    if not rows:
+        st.caption("No hay gastos para este filtro.")
+        st.stop()
+
+    def _fmt_dt(s: str) -> str:
+        try:
+            return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return s
+
+    df = pd.DataFrame(
+        [
+            {
+                "Proveedor": r["supplier_name"],
+                "Descripción": r.get("description", "") or "",
+                "Monto": f"{r['amount']:.2f}",
+                "Categoría": r["category"],
+                "Estado": r["status"],
+                "Solicitante": r.get("requested_by_email", ""),
+                "Creado": _fmt_dt(r["created_at"]),
+            }
             for r in rows
-        }
-        sel_label = st.selectbox(
-            "Selecciona una solicitud",
-            [""] + list(opts.keys()),
-            index=0,
-            key="aprobador_sel",
-        )
-        if not sel_label:
-            st.stop()
-        expense_id = opts[sel_label]
+        ]
+    )
+    st.dataframe(df, use_container_width=True, hide_index=True)
 
-        exp = get_expense_by_id_for_approver(expense_id)
-        if not exp:
-            st.error("No se encontró la solicitud seleccionada.")
-            st.stop()
+    opt_map = {
+        f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['created_at'])}  {r.get('requested_by_email','')}"
+        : r["id"]
+        for r in rows
+    }
+    sel_label = st.selectbox(
+        "Selecciona una solicitud para revisar",
+        list(opt_map.keys()),
+    )
+    eid = opt_map[sel_label]
 
-        left, mid, right = st.columns([2, 1, 3])
+    exp = get_expense_by_id_for_approver(eid)
+    if not exp:
+        return
 
-        # ---- Left: details, logs, comments
-        with left:
-            rec_key = exp.get("supporting_doc_key")
-            pay_key = exp.get("payment_doc_key")
-            details_md = (
-                f"**Proveedor:** {exp['supplier_name']}  \n"
-                f"**Descripción:** {exp.get('description','')}  \n"
-                f"**Monto:** {exp['amount']:.2f}  \n"
-                f"**Categoría:** {exp['category']}  \n"
-                f"**Estado actual:** {exp['status']}  \n"
-                f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
-                f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
-                f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
-            )
-            if exp.get("reimbursement"):
-                details_md += (
-                    f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
-                )
-            st.markdown(details_md)
-            cols_files = st.columns(2)
-            with cols_files[0]:
+    st.markdown(
+        f"**Proveedor:** {exp['supplier_name']}  \n"
+        f"**Descripción:** {exp.get('description','')}  \n"
+        f"**Monto:** {exp['amount']:.2f}  \n"
+        f"**Categoría:** {exp['category']}  \n"
+        f"**Estado:** {exp['status']}  \n"
+        f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+        f"**Creado:** {_fmt_dt(exp['created_at'])}"
+    )
+    rec_key = exp.get("supporting_doc_key")
+    pay_key = exp.get("payment_doc_key")
+    cols_files = st.columns(2)
+    with cols_files[0]:
+        _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
+    with cols_files[1]:
+        _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
 
-                _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
-            with cols_files[1]:
-                _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
-
-
-            st.divider()
-            st.write("**Historial (logs)**")
-            logs = list_expense_logs(expense_id)
-            if not logs:
-                st.caption("Sin historial.")
-            else:
-                log_df = pd.DataFrame(
-                    [
-                        {
-                            "Fecha": _fmt_dt(lg["created_at"]),
-                            "Actor": lg.get("actor_email", ""),
-                            "Mensaje": lg.get("message", ""),
-                        }
-                        for lg in logs
-                    ]
-                )
-                st.dataframe(log_df, use_container_width=True, hide_index=True)
-
-            st.write("**Comentarios**")
-            comments = list_expense_comments(expense_id)
-            if not comments:
-                st.caption("No hay comentarios.")
-            else:
-                com_df = pd.DataFrame(
-                    [
-                        {
-                            "Fecha": _fmt_dt(c["created_at"]),
-                            "Autor": c.get("actor_email", ""),
-                            "Comentario": c["message"],
-                        }
-                        for c in comments
-                    ]
-                )
-                st.dataframe(com_df, use_container_width=True, hide_index=True)
-
-        # ---- Middle: supplier history
-        with right:
-            st.write("**Historial del proveedor**")
-            sup_id = exp.get("supplier_id")
-            hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
-            if hist_rows:
-                hist_df = pd.DataFrame(
-                    [
-                        {
-                            "Descripción": r.get("description", "") or "",
-                            "Monto": f"{r['amount']:.2f}",
-                            "Categoría": r["category"],
-                            "Estado": r["status"],
-                            "Solicitante": r.get("requested_by_email", ""),
-                            "Creado": _fmt_dt(r["created_at"]),
-                        }
-                        for r in hist_rows
-                    ]
-                )
-                st.dataframe(hist_df, use_container_width=True, hide_index=True)
-            else:
-                st.caption("Sin historial.")
-
-        # ---- Right: update status + add comment
-        with mid:
-            st.write("**Actualizar estado / agregar comentario**")
-            # Aprobador puede dejar 'solicitado', 'aprobado' o 'rechazado'
-            estados_actualizables = ["solicitado", "aprobado", "rechazado"]
-            new_status = st.selectbox(
-                "Nuevo estado",
-                options=estados_actualizables,
-                index=estados_actualizables.index(exp["status"]) if exp["status"] in estados_actualizables else 0,
-            )
-            comment = st.text_area("Comentario (opcional)", key="aprobador_comment")
-
-            if st.button("Guardar cambios", type="primary", use_container_width=True):
-                try:
-                    if new_status == exp["status"] and comment.strip():
-                        # Solo comentario
-                        add_expense_comment(expense_id, user_id, comment.strip())
-                    else:
-                        # Cambia estado (y opcionalmente agrega comentario en el log)
-                        update_expense_status(expense_id, user_id, new_status, comment or None)
-                    st.success("Actualización guardada.")
-                    st.session_state.aprobador_comment = ""
-                    st.session_state.aprobador_resumen_needs_refresh = True
-                    st.session_state.aprobador_historial_needs_refresh = True
-                    st.rerun(fragment="aprobador_detalle")
-                except Exception as e:
-                    st.error(f"No se pudo actualizar: {e}")
-
-# ---------------------------------------------------
-# Tab 3 — Historial
-# ---------------------------------------------------
-with tab3:
-    with st.fragment("aprobador_historial"):
-        if st.session_state.get("aprobador_historial_needs_refresh"):
-            st.session_state.aprobador_historial_needs_refresh = False
-            st.rerun(fragment="aprobador_historial")
-
-        st.write("**Historial**")
-
-        modo = st.radio(
-            "Ver por:",
-            options=["Proveedores", "Categorías", "Solicitantes"],
-            horizontal=True,
-        )
-
-        # Load options
-        if modo == "Proveedores":
-            sups = list_suppliers()
-            if not sups:
-                st.caption("No hay proveedores.")
-                st.stop()
-            sup_map = {s["name"]: s["id"] for s in sups}
-            sel_sup_name = st.selectbox("Proveedor", list(sup_map.keys()))
-            rows = list_expenses_by_supplier_id(sup_map[sel_sup_name])
-
-        elif modo == "Categorías":
-            cats = list_categories()
-            if not cats:
-                st.caption("No hay categorías.")
-                st.stop()
-            sel_cat = st.selectbox("Categoría", cats)
-            rows = list_expenses_by_category(sel_cat)
-
-        else:  # "Solicitantes"
-            reqs = list_requesters_for_approver()
-            if not reqs:
-                st.caption("No hay solicitantes con gastos.")
-                st.stop()
-            req_map = {r["email"]: r["id"] for r in reqs}
-            sel_email = st.selectbox("Solicitante", list(req_map.keys()))
-            rows = list_expenses_by_requester(req_map[sel_email])
-
-        # Table of all matching expenses + select one to view
-        if not rows:
-            st.caption("No hay gastos para este filtro.")
-            st.stop()
-
-        def _fmt_dt(s: str) -> str:
-            try:
-                return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
-            except Exception:
-                return s
-
-        df = pd.DataFrame(
+    st.divider()
+    logs = list_expense_logs(eid)
+    if logs:
+        log_df = pd.DataFrame(
             [
                 {
-                    "Proveedor": r["supplier_name"],
-                    "Descripción": r.get("description", "") or "",
-                    "Monto": f"{r['amount']:.2f}",
-                    "Categoría": r["category"],
-                    "Estado": r["status"],
-                    "Solicitante": r.get("requested_by_email", ""),
-                    "Creado": _fmt_dt(r["created_at"]),
+                    "Fecha": _fmt_dt(l["created_at"]),
+                    "Actor": l.get("actor_email", ""),
+                    "Mensaje": l.get("message", ""),
                 }
-                for r in rows
+                for l in logs
             ]
         )
-        st.dataframe(df, use_container_width=True, hide_index=True)
+        st.write("**Historial (logs)**")
+        st.dataframe(log_df, use_container_width=True, hide_index=True)
 
-        # Select one to show details, comments and logs
-        opt_map = {
-            f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['created_at'])}  {r.get('requested_by_email','')}"
-            : r["id"]
-            for r in rows
-        }
-        sel_label = st.selectbox("Selecciona una solicitud para revisar", list(opt_map.keys()))
-        eid = opt_map[sel_label]
+    comments = list_expense_comments(eid)
+    if comments:
+        com_df = pd.DataFrame(
+            [
+                {
+                    "Fecha": _fmt_dt(c["created_at"]),
+                    "Autor": c.get("actor_email", ""),
+                    "Comentario": c["message"],
+                }
+                for c in comments
+            ]
+        )
+        st.write("**Comentarios**")
+        st.dataframe(com_df, use_container_width=True, hide_index=True)
 
-        exp = get_expense_by_id_for_approver(eid)
-        if exp:
-            st.markdown(
-                f"**Proveedor:** {exp['supplier_name']}  \n"
-                f"**Descripción:** {exp.get('description','')}  \n"
-                f"**Monto:** {exp['amount']:.2f}  \n"
-                f"**Categoría:** {exp['category']}  \n"
-                f"**Estado:** {exp['status']}  \n"
-                f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
-                f"**Creado:** {_fmt_dt(exp['created_at'])}"
-            )
-            rec_key = exp.get("supporting_doc_key")
-            pay_key = exp.get("payment_doc_key")
-            cols_files = st.columns(2)
-            with cols_files[0]:
 
-                _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
-            with cols_files[1]:
-                _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
+with tab1:
+    aprobador_resumen_fragment()
 
-            st.divider()
-            logs = list_expense_logs(eid)
-            if logs:
-                log_df = pd.DataFrame(
-                    [{"Fecha": _fmt_dt(l["created_at"]), "Actor": l.get("actor_email",""), "Mensaje": l.get("message","")} for l in logs]
-                )
-                st.write("**Historial (logs)**")
-                st.dataframe(log_df, use_container_width=True, hide_index=True)
+with tab2:
+    aprobador_detalle_fragment()
 
-            comments = list_expense_comments(eid)
-            if comments:
-                com_df = pd.DataFrame(
-                    [{"Fecha": _fmt_dt(c["created_at"]), "Autor": c.get("actor_email",""), "Comentario": c["message"]} for c in comments]
-                )
-                st.write("**Comentarios**")
-                st.dataframe(com_df, use_container_width=True, hide_index=True)
+with tab3:
+    aprobador_historial_fragment()
+

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -68,471 +68,494 @@ st.session_state.setdefault("pagador_sel", "")
 st.session_state.setdefault("pagador_comment", "")
 st.session_state.setdefault("pagador_selected_expense_id", None)
 
-# ---------------------------------------------------
-# Tab 1 — Solicitudes
-# ---------------------------------------------------
-with tab1:
-    with st.fragment("pagador_resumen"):
-        st.write("**Solicitudes**")
 
-        _ = st.session_state.get("pagador_resumen_refresh_token")
-        all_rows = list_expenses_for_status(status=None) or []
+@st.fragment
+def pagador_resumen_fragment():
+    st.write("**Solicitudes**")
 
-        # Métricas por estado
-        counts = {e: 0 for e in ESTADOS}
-        for r in all_rows:
-            if r["status"] in counts:
-                counts[r["status"]] += 1
-        cols = st.columns(len(ESTADOS))
-        for i, e in enumerate(ESTADOS):
-            cols[i].metric(e.capitalize(), counts[e])
+    _ = st.session_state.get("pagador_resumen_refresh_token")
+    all_rows = list_expenses_for_status(status=None) or []
 
-        st.divider()
+    counts = {e: 0 for e in ESTADOS}
+    for r in all_rows:
+        if r["status"] in counts:
+            counts[r["status"]] += 1
+    cols = st.columns(len(ESTADOS))
+    for i, e in enumerate(ESTADOS):
+        cols[i].metric(e.capitalize(), counts[e])
 
-        # Filtro por estado (por defecto, 'aprobado' es el más relevante para Pagador)
-        estados_opts = ["(todos)"] + ESTADOS
-        default_status = st.session_state.get("pagador_resumen_estado", "aprobado")
-        if default_status not in estados_opts:
-            default_status = estados_opts[0]
-        selected_status = st.selectbox(
-            "Filtrar por estado",
-            options=estados_opts,
-            index=estados_opts.index(default_status),
-            key="pagador_resumen_estado",
-        )
-        rows = (
-            all_rows
-            if selected_status == "(todos)"
-            else [r for r in all_rows if r["status"] == selected_status]
-        )
+    st.divider()
 
-        if not rows:
-            st.caption("No hay solicitudes para este filtro.")
+    estados_opts = ["(todos)"] + ESTADOS
+    default_status = st.session_state.get("pagador_resumen_estado", "aprobado")
+    if default_status not in estados_opts:
+        default_status = estados_opts[0]
+    selected_status = st.selectbox(
+        "Filtrar por estado",
+        options=estados_opts,
+        index=estados_opts.index(default_status),
+        key="pagador_resumen_estado",
+    )
+    rows = (
+        all_rows
+        if selected_status == "(todos)"
+        else [r for r in all_rows if r["status"] == selected_status]
+    )
+
+    if not rows:
+        st.caption("No hay solicitudes para este filtro.")
+        return
+
+    df = pd.DataFrame(
+        [
+            {
+                "Solicitante": r.get("requested_by_email", ""),
+                "Monto": f"{r['amount']:.2f}",
+                "Descripción": r.get("description") or "",
+                "Categoría": r["category"],
+                "Proveedor": r["supplier_name"],
+                "Creado": _fmt_dt(r["created_at"]),
+            }
+            for r in rows
+        ]
+    )
+    st.dataframe(df, use_container_width=True, hide_index=True)
+
+
+@st.fragment
+def pagador_detalle_fragment():
+    st.write("**Detalles y marcar pagado**")
+
+    estado_options = ["aprobado", "pagado", "solicitado", "rechazado"]
+    st.session_state.setdefault("pagador_estado_sel", estado_options[0])
+    estado_sel = st.radio(
+        "Elegir estado para seleccionar solicitudes:",
+        options=estado_options,
+        horizontal=True,
+        key="pagador_estado_sel",
+    )
+
+    state_rows = list_expenses_for_status(status=estado_sel) or []
+    rows = list(state_rows)
+    selected_id = st.session_state.get("pagador_selected_expense_id")
+    if selected_id and all(r["id"] != selected_id for r in rows):
+        extra = get_expense_by_id_for_approver(selected_id)
+        if extra:
+            rows.append(extra)
+
+    labels = [""]
+    label_to_id = {}
+    for r in rows:
+        label = _expense_label(r)
+        if label not in label_to_id:
+            labels.append(label)
+            label_to_id[label] = r["id"]
+
+    if len(labels) == 1:
+        st.caption("No hay solicitudes en este estado.")
+
+    sel_label = st.selectbox(
+        "Selecciona una solicitud",
+        labels,
+        key="pagador_sel",
+    )
+
+    if sel_label:
+        expense_id = label_to_id.get(sel_label)
+        if not expense_id:
+            st.error("No se encontró la solicitud seleccionada.")
         else:
-            df = pd.DataFrame(
-                [
-                    {
-                        "Solicitante": r.get("requested_by_email", ""),
-                        "Monto": f"{r['amount']:.2f}",
-                        "Descripción": r.get("description") or "",
-                        "Categoría": r["category"],
-                        "Proveedor": r["supplier_name"],
-                        "Creado": _fmt_dt(r["created_at"]),
-                    }
-                    for r in rows
-                ]
-            )
-            st.dataframe(df, use_container_width=True, hide_index=True)
-
-# ---------------------------------------------------
-# Tab 2 — Detalles y marcar pagado
-# ---------------------------------------------------
-with tab2:
-    with st.fragment("pagador_detalle"):
-        st.write("**Detalles y marcar pagado**")
-
-        estado_options = ["aprobado", "pagado", "solicitado", "rechazado"]
-        st.session_state.setdefault("pagador_estado_sel", estado_options[0])
-        estado_sel = st.radio(
-            "Elegir estado para seleccionar solicitudes:",
-            options=estado_options,
-            horizontal=True,
-            key="pagador_estado_sel",
-        )
-
-        state_rows = list_expenses_for_status(status=estado_sel) or []
-        rows = list(state_rows)
-        selected_id = st.session_state.get("pagador_selected_expense_id")
-        if selected_id and all(r["id"] != selected_id for r in rows):
-            extra = get_expense_by_id_for_approver(selected_id)
-            if extra:
-                rows.append(extra)
-
-        labels = [""]
-        label_to_id = {}
-        for r in rows:
-            label = _expense_label(r)
-            if label not in label_to_id:
-                labels.append(label)
-                label_to_id[label] = r["id"]
-
-        if len(labels) == 1:
-            st.caption("No hay solicitudes en este estado.")
-
-        sel_label = st.selectbox(
-            "Selecciona una solicitud",
-            labels,
-            key="pagador_sel",
-        )
-
-        if sel_label:
-            expense_id = label_to_id.get(sel_label)
-            if not expense_id:
+            st.session_state.pagador_selected_expense_id = expense_id
+            exp = get_expense_by_id_for_approver(expense_id)
+            if not exp:
                 st.error("No se encontró la solicitud seleccionada.")
             else:
-                st.session_state.pagador_selected_expense_id = expense_id
-                exp = get_expense_by_id_for_approver(expense_id)
-                if not exp:
-                    st.error("No se encontró la solicitud seleccionada.")
-                else:
-                    rec_key = exp.get("supporting_doc_key")
-                    pay_key = exp.get("payment_doc_key")
-                    left, mid, right = st.columns([2, 1, 3])
+                rec_key = exp.get("supporting_doc_key")
+                pay_key = exp.get("payment_doc_key")
+                left, mid, right = st.columns([2, 1, 3])
 
-                    # ---- Izquierda: detalles + docs + logs + comentarios
-                    with left:
-                        detalles_md = (
-                            f"**Proveedor:** {exp['supplier_name']}  \n"
-                            f"**Descripción:** {exp.get('description','')}  \n"
-                            f"**Monto:** {exp['amount']:.2f}  \n"
-                            f"**Categoría:** {exp['category']}  \n"
-                            f"**Estado actual:** {exp['status']}  \n"
-                            f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
-                            f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
-                            f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
-                        )
-                        if exp.get("reimbursement"):
-                            detalles_md += (
-                                f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
-                            )
-                        st.markdown(detalles_md)
-
-                        cols_files = st.columns(2)
-                        with cols_files[0]:
-                            _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
-                        with cols_files[1]:
-                            _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
-
-                        st.divider()
-                        st.write("**Historial (logs)**")
-                        logs = list_expense_logs(expense_id)
-                        if logs:
-                            log_df = pd.DataFrame(
-                                [
-                                    {
-                                        "Fecha": _fmt_dt(l["created_at"]),
-                                        "Actor": l.get("actor_email", ""),
-                                        "Mensaje": l.get("message", ""),
-                                    }
-                                    for l in logs
-                                ]
-                            )
-                            st.dataframe(log_df, use_container_width=True, hide_index=True)
-                        else:
-                            st.caption("Sin historial.")
-
-                        st.write("**Comentarios**")
-                        comments = list_expense_comments(expense_id)
-                        if comments:
-                            com_df = pd.DataFrame(
-                                [
-                                    {
-                                        "Fecha": _fmt_dt(c["created_at"]),
-                                        "Autor": c.get("actor_email", ""),
-                                        "Comentario": c["message"],
-                                    }
-                                    for c in comments
-                                ]
-                            )
-                            st.dataframe(com_df, use_container_width=True, hide_index=True)
-                        else:
-                            st.caption("No hay comentarios.")
-
-                    # ---- Medio: historial del proveedor
-                    with right:
-                        st.write("**Historial del proveedor**")
-                        sup_id = exp.get("supplier_id")
-                        hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
-                        if hist_rows:
-                            hist_df = pd.DataFrame(
-                                [
-                                    {
-                                        "Descripción": r.get("description", "") or "",
-                                        "Monto": f"{r['amount']:.2f}",
-                                        "Categoría": r["category"],
-                                        "Estado": r["status"],
-                                        "Solicitante": r.get("requested_by_email", ""),
-                                        "Creado": _fmt_dt(r["created_at"]),
-                                    }
-                                    for r in hist_rows
-                                ]
-                            )
-                            st.dataframe(hist_df, use_container_width=True, hide_index=True)
-                        else:
-                            st.caption("Sin historial.")
-
-                    # ---- Derecha: marcar pagado / comentario
-                    with mid:
-                        st.write("**Actualizar estado / marcar pagado**")
-
-                        estados_pagador = ["aprobado", "pagado", "rechazado"]  # Pagador puede rechazar
-                        new_status = st.selectbox(
-                            "Nuevo estado",
-                            options=estados_pagador,
-                            index=estados_pagador.index(exp["status"]) if exp["status"] in estados_pagador else 0,
-                        )
-
-                        existing_payment_date_raw = exp.get("payment_date")
-                        existing_payment_date = None
-                        if existing_payment_date_raw:
-                            try:
-                                existing_payment_date = pd.to_datetime(existing_payment_date_raw).date()
-                            except Exception:
-                                existing_payment_date = None
-
-                        payment_date = existing_payment_date or date.today()
-                        if new_status == "pagado":
-                            hoy = st.checkbox(
-                                "fecha de pago hoy",
-                                value=existing_payment_date is None,
-                            )
-                            if hoy:
-                                payment_date = date.today()
-                            else:
-                                payment_date = st.date_input(
-                                    "Fecha de pago",
-                                    value=payment_date,
-                                )
-                        else:
-                            payment_date = None
-                        pay_file = st.file_uploader(
-                            "Comprobante de pago (opcional)",
-                            type=["pdf", "png", "jpg", "jpeg", "webp"],
-                        )
-                        comment = st.text_area("Comentario (opcional)", key="pagador_comment")
-
-                        if st.button("Guardar cambios", type="primary", use_container_width=True):
-                            try:
-                                comment_clean = (comment or "").strip()
-                                status_changed = new_status != exp["status"]
-                                triggered_refresh = False
-
-                                if new_status == "pagado":
-                                    payment_doc_key = None
-                                    if pay_file:
-                                        sb = get_client()
-                                        bucket = "payments"
-                                        file_id = uuid.uuid4().hex + Path(pay_file.name).suffix
-                                        sb.storage.from_(bucket).upload(
-                                            file_id,
-                                            pay_file.getvalue(),
-                                            {"content-type": pay_file.type},
-                                        )
-                                        payment_doc_key = file_id
-
-                                    payment_date_dt = payment_date or date.today()
-                                    payment_date_changed = False
-                                    if status_changed:
-                                        payment_date_changed = True
-                                    elif existing_payment_date:
-                                        payment_date_changed = payment_date_dt != existing_payment_date
-                                    else:
-                                        payment_date_changed = True
-
-                                    if status_changed or payment_doc_key or payment_date_changed:
-                                        mark_expense_as_paid(
-                                            expense_id=expense_id,
-                                            actor_id=user_id,
-                                            payment_doc_key=payment_doc_key,
-                                            payment_date=payment_date_dt.strftime("%Y-%m-%d"),
-                                            comment=comment_clean or None,
-                                        )
-                                        msg = "Solicitud marcada como pagada."
-                                        if not status_changed:
-                                            msg = "Solicitud actualizada."
-                                        st.success(msg)
-                                        triggered_refresh = True
-                                        if status_changed:
-                                            st.session_state.pagador_resumen_refresh_token += 1
-                                            st.session_state.pagador_historial_refresh_token += 1
-                                    elif comment_clean:
-                                        add_expense_comment(expense_id, user_id, comment_clean)
-                                        st.success("Comentario agregado.")
-                                        triggered_refresh = True
-                                    else:
-                                        st.info("No hay cambios que guardar.")
-                                else:
-                                    if pay_file:
-                                        st.warning("El comprobante de pago solo se adjunta al marcar como pagado.")
-                                    if comment_clean:
-                                        add_expense_comment(expense_id, user_id, comment_clean)
-                                        st.success("Comentario agregado.")
-                                        triggered_refresh = True
-                                    else:
-                                        st.info("No hay cambios que guardar.")
-
-                                if triggered_refresh:
-                                    st.session_state.pagador_comment = ""
-                                    st.session_state.pagador_estado_sel = new_status
-                                    st.session_state.pagador_sel = _expense_label(exp)
-                                    st.rerun(fragment="pagador_detalle")
-                            except Exception as e:
-                                st.error(f"No se pudo actualizar: {e}")
-        else:
-            st.session_state.pagador_selected_expense_id = None
-
-# ---------------------------------------------------
-# Tab 3 — Historial
-# ---------------------------------------------------
-with tab3:
-    with st.fragment("pagador_historial"):
-        st.write("**Historial**")
-
-        _ = st.session_state.get("pagador_historial_refresh_token")
-
-        modo_opts = ["Proveedores", "Categorías", "Solicitantes"]
-        st.session_state.setdefault("pagador_historial_modo", modo_opts[0])
-        modo = st.radio(
-            "Ver por:",
-            options=modo_opts,
-            horizontal=True,
-            key="pagador_historial_modo",
-        )
-
-        rows = []
-        has_options = True
-
-        if modo == "Proveedores":
-            sups = list_suppliers()
-            if not sups:
-                has_options = False
-                st.caption("No hay proveedores.")
-            else:
-                sup_names = [s["name"] for s in sups]
-                sup_map = {s["name"]: s["id"] for s in sups}
-                if st.session_state.get("pagador_historial_supplier") not in sup_map:
-                    st.session_state["pagador_historial_supplier"] = sup_names[0]
-                sel_sup_name = st.selectbox(
-                    "Proveedor",
-                    sup_names,
-                    key="pagador_historial_supplier",
-                )
-                rows = list_expenses_by_supplier_id(sup_map[sel_sup_name])
-
-        elif modo == "Categorías":
-            cats = list_categories()
-            if not cats:
-                has_options = False
-                st.caption("No hay categorías.")
-            else:
-                if st.session_state.get("pagador_historial_category") not in cats:
-                    st.session_state["pagador_historial_category"] = cats[0]
-                sel_cat = st.selectbox(
-                    "Categoría",
-                    cats,
-                    key="pagador_historial_category",
-                )
-                rows = list_expenses_by_category(sel_cat)
-
-        else:  # "Solicitantes"
-            reqs = list_requesters_for_approver()
-            if not reqs:
-                has_options = False
-                st.caption("No hay solicitantes con gastos.")
-            else:
-                emails = [r["email"] for r in reqs]
-                req_map = {r["email"]: r["id"] for r in reqs}
-                if st.session_state.get("pagador_historial_requester") not in req_map:
-                    st.session_state["pagador_historial_requester"] = emails[0]
-                sel_email = st.selectbox(
-                    "Solicitante",
-                    emails,
-                    key="pagador_historial_requester",
-                )
-                rows = list_expenses_by_requester(req_map[sel_email])
-
-        if has_options:
-            if not rows:
-                st.caption("No hay gastos para este filtro.")
-            else:
-                df = pd.DataFrame(
-                    [
-                        {
-                            "Proveedor": r["supplier_name"],
-                            "Descripción": r.get("description", "") or "",
-                            "Monto": f"{r['amount']:.2f}",
-                            "Categoría": r["category"],
-                            "Estado": r["status"],
-                            "Solicitante": r.get("requested_by_email", ""),
-                            "Creado": _fmt_dt(r["created_at"]),
-                        }
-                        for r in rows
-                    ]
-                )
-                st.dataframe(df, use_container_width=True, hide_index=True)
-
-                label_to_id = {}
-                labels = []
-                for r in rows:
-                    label = _expense_label(r)
-                    label_to_id[label] = r["id"]
-                    labels.append(label)
-
-                if labels:
-                    current_hist_sel = st.session_state.get("pagador_historial_sel")
-                    if current_hist_sel not in label_to_id:
-                        st.session_state["pagador_historial_sel"] = labels[0]
-                    sel_label = st.selectbox(
-                        "Selecciona una solicitud para revisar",
-                        labels,
-                        key="pagador_historial_sel",
+                with left:
+                    detalles_md = (
+                        f"**Proveedor:** {exp['supplier_name']}  \n"
+                        f"**Descripción:** {exp.get('description','')}  \n"
+                        f"**Monto:** {exp['amount']:.2f}  \n"
+                        f"**Categoría:** {exp['category']}  \n"
+                        f"**Estado actual:** {exp['status']}  \n"
+                        f"**Creado:** {_fmt_dt(exp['created_at'])}  \n"
+                        f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+                        f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
                     )
-                    eid = label_to_id.get(sel_label)
+                    if exp.get("reimbursement"):
+                        detalles_md += (
+                            f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
+                        )
+                    st.markdown(detalles_md)
 
-                    if eid:
-                        exp = get_expense_by_id_for_approver(eid)
-                        if exp:
-                            st.markdown(
-                                f"**Proveedor:** {exp['supplier_name']}  \n"
-                                f"**Descripción:** {exp.get('description','')}  \n"
-                                f"**Monto:** {exp['amount']:.2f}  \n"
-                                f"**Categoría:** {exp['category']}  \n"
-                                f"**Estado:** {exp['status']}  \n"
-                                f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
-                                f"**Creado:** {_fmt_dt(exp['created_at'])}"
-                            )
-                            rec_key = exp.get("supporting_doc_key")
+                    cols_files = st.columns(2)
+                    with cols_files[0]:
+                        _render_download(
+                            rec_key,
+                            "Documento de respaldo",
+                            signed_url_for_receipt,
+                        )
+                    with cols_files[1]:
+                        _render_download(
+                            pay_key,
+                            "Comprobante de pago",
+                            signed_url_for_payment,
+                        )
 
-                            pay_key = exp.get("payment_doc_key")
-                            cols_files = st.columns(2)
-                            with cols_files[0]:
-                                _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
-                            with cols_files[1]:
-                                _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
+                    st.divider()
+                    st.write("**Historial (logs)**")
+                    logs = list_expense_logs(expense_id)
+                    if logs:
+                        log_df = pd.DataFrame(
+                            [
+                                {
+                                    "Fecha": _fmt_dt(l["created_at"]),
+                                    "Actor": l.get("actor_email", ""),
+                                    "Mensaje": l.get("message", ""),
+                                }
+                                for l in logs
+                            ]
+                        )
+                        st.dataframe(log_df, use_container_width=True, hide_index=True)
+                    else:
+                        st.caption("Sin historial.")
 
-                            st.divider()
-                            logs = list_expense_logs(eid)
-                            if logs:
-                                log_df = pd.DataFrame(
-                                    [
-                                        {
-                                            "Fecha": _fmt_dt(l["created_at"]),
-                                            "Actor": l.get("actor_email", ""),
-                                            "Mensaje": l.get("message", ""),
-                                        }
-                                        for l in logs
-                                    ]
-                                )
-                                st.write("**Historial (logs)**")
-                                st.dataframe(log_df, use_container_width=True, hide_index=True)
+                    st.write("**Comentarios**")
+                    comments = list_expense_comments(expense_id)
+                    if comments:
+                        com_df = pd.DataFrame(
+                            [
+                                {
+                                    "Fecha": _fmt_dt(c["created_at"]),
+                                    "Autor": c.get("actor_email", ""),
+                                    "Comentario": c["message"],
+                                }
+                                for c in comments
+                            ]
+                        )
+                        st.dataframe(com_df, use_container_width=True, hide_index=True)
+                    else:
+                        st.caption("No hay comentarios.")
 
-                            comments = list_expense_comments(eid)
-                            if comments:
-                                com_df = pd.DataFrame(
-                                    [
-                                        {
-                                            "Fecha": _fmt_dt(c["created_at"]),
-                                            "Autor": c.get("actor_email", ""),
-                                            "Comentario": c["message"],
-                                        }
-                                        for c in comments
-                                    ]
-                                )
-                                st.write("**Comentarios**")
-                                st.dataframe(com_df, use_container_width=True, hide_index=True)
-                            else:
-                                st.caption("No hay comentarios.")
+                with right:
+                    st.write("**Historial del proveedor**")
+                    sup_id = exp.get("supplier_id")
+                    hist_rows = list_expenses_by_supplier_id(sup_id) if sup_id else []
+                    if hist_rows:
+                        hist_df = pd.DataFrame(
+                            [
+                                {
+                                    "Descripción": r.get("description", "") or "",
+                                    "Monto": f"{r['amount']:.2f}",
+                                    "Categoría": r["category"],
+                                    "Estado": r["status"],
+                                    "Solicitante": r.get("requested_by_email", ""),
+                                    "Creado": _fmt_dt(r["created_at"]),
+                                }
+                                for r in hist_rows
+                            ]
+                        )
+                        st.dataframe(hist_df, use_container_width=True, hide_index=True)
+                    else:
+                        st.caption("Sin historial.")
+
+                with mid:
+                    st.write("**Actualizar estado / marcar pagado**")
+
+                    estados_pagador = ["aprobado", "pagado", "rechazado"]
+                    new_status = st.selectbox(
+                        "Nuevo estado",
+                        options=estados_pagador,
+                        index=(
+                            estados_pagador.index(exp["status"])
+                            if exp["status"] in estados_pagador
+                            else 0
+                        ),
+                    )
+
+                    existing_payment_date_raw = exp.get("payment_date")
+                    existing_payment_date = None
+                    if existing_payment_date_raw:
+                        try:
+                            existing_payment_date = pd.to_datetime(
+                                existing_payment_date_raw
+                            ).date()
+                        except Exception:
+                            existing_payment_date = None
+
+                    payment_date = existing_payment_date or date.today()
+                    if new_status == "pagado":
+                        hoy = st.checkbox(
+                            "fecha de pago hoy",
+                            value=existing_payment_date is None,
+                        )
+                        if hoy:
+                            payment_date = date.today()
                         else:
-                            st.warning("No se encontró la solicitud seleccionada.")
-                else:
-                    st.caption("No hay solicitudes para revisar.")
+                            payment_date = st.date_input(
+                                "Fecha de pago",
+                                value=payment_date,
+                            )
+                    else:
+                        payment_date = None
+                    pay_file = st.file_uploader(
+                        "Comprobante de pago (opcional)",
+                        type=["pdf", "png", "jpg", "jpeg", "webp"],
+                    )
+                    comment = st.text_area("Comentario (opcional)", key="pagador_comment")
+
+                    if st.button("Guardar cambios", type="primary", use_container_width=True):
+                        try:
+                            comment_clean = (comment or "").strip()
+                            status_changed = new_status != exp["status"]
+                            triggered_refresh = False
+
+                            if new_status == "pagado":
+                                payment_doc_key = None
+                                if pay_file:
+                                    sb = get_client()
+                                    bucket = "payments"
+                                    file_id = uuid.uuid4().hex + Path(pay_file.name).suffix
+                                    sb.storage.from_(bucket).upload(
+                                        file_id,
+                                        pay_file.getvalue(),
+                                        {"content-type": pay_file.type},
+                                    )
+                                    payment_doc_key = file_id
+
+                                payment_date_dt = payment_date or date.today()
+                                payment_date_changed = False
+                                if status_changed:
+                                    payment_date_changed = True
+                                elif existing_payment_date:
+                                    payment_date_changed = payment_date_dt != existing_payment_date
+                                else:
+                                    payment_date_changed = True
+
+                                if status_changed or payment_doc_key or payment_date_changed:
+                                    mark_expense_as_paid(
+                                        expense_id=expense_id,
+                                        actor_id=user_id,
+                                        payment_doc_key=payment_doc_key,
+                                        payment_date=payment_date_dt.strftime("%Y-%m-%d"),
+                                        comment=comment_clean or None,
+                                    )
+                                    msg = "Solicitud marcada como pagada."
+                                    if not status_changed:
+                                        msg = "Solicitud actualizada."
+                                    st.success(msg)
+                                    triggered_refresh = True
+                                    if status_changed:
+                                        st.session_state.pagador_resumen_refresh_token += 1
+                                        st.session_state.pagador_historial_refresh_token += 1
+                                elif comment_clean:
+                                    add_expense_comment(expense_id, user_id, comment_clean)
+                                    st.success("Comentario agregado.")
+                                    triggered_refresh = True
+                                else:
+                                    st.info("No hay cambios que guardar.")
+                            else:
+                                if pay_file:
+                                    st.warning(
+                                        "El comprobante de pago solo se adjunta al marcar como pagado."
+                                    )
+                                if comment_clean:
+                                    add_expense_comment(expense_id, user_id, comment_clean)
+                                    st.success("Comentario agregado.")
+                                    triggered_refresh = True
+                                else:
+                                    st.info("No hay cambios que guardar.")
+
+                            if triggered_refresh:
+                                st.session_state.pagador_comment = ""
+                                st.session_state.pagador_estado_sel = new_status
+                                st.session_state.pagador_sel = _expense_label(exp)
+                                st.rerun(scope="fragment")
+                        except Exception as e:
+                            st.error(f"No se pudo actualizar: {e}")
+    else:
+        st.session_state.pagador_selected_expense_id = None
+
+
+@st.fragment
+def pagador_historial_fragment():
+    st.write("**Historial**")
+
+    _ = st.session_state.get("pagador_historial_refresh_token")
+
+    modo_opts = ["Proveedores", "Categorías", "Solicitantes"]
+    st.session_state.setdefault("pagador_historial_modo", modo_opts[0])
+    modo = st.radio(
+        "Ver por:",
+        options=modo_opts,
+        horizontal=True,
+        key="pagador_historial_modo",
+    )
+
+    rows = []
+    has_options = True
+
+    if modo == "Proveedores":
+        sups = list_suppliers()
+        if not sups:
+            has_options = False
+            st.caption("No hay proveedores.")
+        else:
+            sup_names = [s["name"] for s in sups]
+            sup_map = {s["name"]: s["id"] for s in sups}
+            if st.session_state.get("pagador_historial_supplier") not in sup_map:
+                st.session_state["pagador_historial_supplier"] = sup_names[0]
+            sel_sup_name = st.selectbox(
+                "Proveedor",
+                sup_names,
+                key="pagador_historial_supplier",
+            )
+            rows = list_expenses_by_supplier_id(sup_map[sel_sup_name])
+
+    elif modo == "Categorías":
+        cats = list_categories()
+        if not cats:
+            has_options = False
+            st.caption("No hay categorías.")
+        else:
+            if st.session_state.get("pagador_historial_category") not in cats:
+                st.session_state["pagador_historial_category"] = cats[0]
+            sel_cat = st.selectbox(
+                "Categoría",
+                cats,
+                key="pagador_historial_category",
+            )
+            rows = list_expenses_by_category(sel_cat)
+
+    else:
+        reqs = list_requesters_for_approver()
+        if not reqs:
+            has_options = False
+            st.caption("No hay solicitantes con gastos.")
+        else:
+            emails = [r["email"] for r in reqs]
+            req_map = {r["email"]: r["id"] for r in reqs}
+            if st.session_state.get("pagador_historial_requester") not in req_map:
+                st.session_state["pagador_historial_requester"] = emails[0]
+            sel_email = st.selectbox(
+                "Solicitante",
+                emails,
+                key="pagador_historial_requester",
+            )
+            rows = list_expenses_by_requester(req_map[sel_email])
+
+    if not has_options:
+        return
+
+    if not rows:
+        st.caption("No hay gastos para este filtro.")
+        return
+
+    df = pd.DataFrame(
+        [
+            {
+                "Proveedor": r["supplier_name"],
+                "Descripción": r.get("description", "") or "",
+                "Monto": f"{r['amount']:.2f}",
+                "Categoría": r["category"],
+                "Estado": r["status"],
+                "Solicitante": r.get("requested_by_email", ""),
+                "Creado": _fmt_dt(r["created_at"]),
+            }
+            for r in rows
+        ]
+    )
+    st.dataframe(df, use_container_width=True, hide_index=True)
+
+    label_to_id = {}
+    labels = []
+    for r in rows:
+        label = _expense_label(r)
+        label_to_id[label] = r["id"]
+        labels.append(label)
+
+    if not labels:
+        st.caption("No hay solicitudes para revisar.")
+        return
+
+    current_hist_sel = st.session_state.get("pagador_historial_sel")
+    if current_hist_sel not in label_to_id:
+        st.session_state["pagador_historial_sel"] = labels[0]
+    sel_label = st.selectbox(
+        "Selecciona una solicitud para revisar",
+        labels,
+        key="pagador_historial_sel",
+    )
+    eid = label_to_id.get(sel_label)
+
+    if not eid:
+        return
+
+    exp = get_expense_by_id_for_approver(eid)
+    if not exp:
+        st.warning("No se encontró la solicitud seleccionada.")
+        return
+
+    st.markdown(
+        f"**Proveedor:** {exp['supplier_name']}  \n"
+        f"**Descripción:** {exp.get('description','')}  \n"
+        f"**Monto:** {exp['amount']:.2f}  \n"
+        f"**Categoría:** {exp['category']}  \n"
+        f"**Estado:** {exp['status']}  \n"
+        f"**Solicitante:** {exp.get('requested_by_email','')}  \n"
+        f"**Creado:** {_fmt_dt(exp['created_at'])}"
+    )
+    rec_key = exp.get("supporting_doc_key")
+    pay_key = exp.get("payment_doc_key")
+    cols_files = st.columns(2)
+    with cols_files[0]:
+        _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
+    with cols_files[1]:
+        _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
+
+    st.divider()
+    logs = list_expense_logs(eid)
+    if logs:
+        log_df = pd.DataFrame(
+            [
+                {
+                    "Fecha": _fmt_dt(l["created_at"]),
+                    "Actor": l.get("actor_email", ""),
+                    "Mensaje": l.get("message", ""),
+                }
+                for l in logs
+            ]
+        )
+        st.write("**Historial (logs)**")
+        st.dataframe(log_df, use_container_width=True, hide_index=True)
+
+    comments = list_expense_comments(eid)
+    if comments:
+        com_df = pd.DataFrame(
+            [
+                {
+                    "Fecha": _fmt_dt(c["created_at"]),
+                    "Autor": c.get("actor_email", ""),
+                    "Comentario": c["message"],
+                }
+                for c in comments
+            ]
+        )
+        st.write("**Comentarios**")
+        st.dataframe(com_df, use_container_width=True, hide_index=True)
+    else:
+        st.caption("No hay comentarios.")
+
+
+with tab1:
+    pagador_resumen_fragment()
+
+with tab2:
+    pagador_detalle_fragment()
+
+with tab3:
+    pagador_historial_fragment()
+

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -40,170 +40,302 @@ if "solicitudes_metrics_dirty" not in st.session_state:
 if "solicitudes_rows_all" not in st.session_state:
     st.session_state.solicitudes_rows_all = None
 
+
+@st.fragment
+def solicitud_nueva_fragment():
+    st.write("**Crear nueva solicitud**")
+
+    if st.session_state.get("reset_form"):
+        st.session_state.reset_form = False
+        st.session_state["sup_name"] = ""
+        st.session_state["monto"] = 0.0
+        st.session_state["descripcion"] = ""
+        st.session_state["comentario"] = ""
+        st.session_state.pop("archivo", None)
+        st.session_state["categoria"] = ""
+        st.session_state["reembolso"] = False
+        st.session_state["reembolso_persona"] = ""
+
+    if "sup_name" not in st.session_state:
+        st.session_state["sup_name"] = ""
+    if "monto" not in st.session_state:
+        st.session_state["monto"] = 0.0
+    if "descripcion" not in st.session_state:
+        st.session_state["descripcion"] = ""
+    if "comentario" not in st.session_state:
+        st.session_state["comentario"] = ""
+    if "categoria" not in st.session_state:
+        st.session_state["categoria"] = ""
+    if "reembolso" not in st.session_state:
+        st.session_state["reembolso"] = False
+    if "reembolso_persona" not in st.session_state:
+        st.session_state["reembolso_persona"] = ""
+
+    suppliers = list_suppliers()
+    if not suppliers:
+        st.info("Aún no hay proveedores. Pide a un administrador que cree al menos uno.")
+    sup_opts = {s["name"]: {"id": s["id"], "category": s.get("category") or ""} for s in suppliers}
+    sup_name = st.selectbox(
+        "Proveedor *",
+        options=[""] + list(sup_opts.keys()),
+        key="sup_name",
+    )
+    sel_sup = sup_opts.get(sup_name) if sup_name else None
+    supplier_id = sel_sup["id"] if sel_sup else None
+    categoria = sel_sup["category"] if sel_sup else ""
+
+    col_a, col_b = st.columns([1, 1])
+    with col_a:
+        amount = st.number_input(
+            "Monto *", min_value=0.00, step=0.01, format="%.2f", key="monto"
+        )
+    with col_b:
+        st.session_state["categoria"] = categoria
+        st.selectbox(
+            "Categoría *",
+            options=[categoria] if categoria else [""],
+            key="categoria",
+            disabled=True,
+        )
+
+    descripcion = st.text_input(
+        "Descripción breve *",
+        placeholder="Ej. Suscripción anual de software...",
+        key="descripcion",
+    )
+
+    file = st.file_uploader(
+        "Documento de respaldo (recibo/factura) *",
+        type=["pdf", "png", "jpg", "jpeg", "webp"],
+        key="archivo",
+    )
+    comentario_inicial = st.text_area(
+        "Comentario (opcional)",
+        placeholder="Ej. Detalles útiles para aprobación…",
+        key="comentario",
+    )
+
+    reembolso = st.checkbox("Reembolso", key="reembolso")
+    personas = list_people() if reembolso else []
+    if reembolso:
+        if personas:
+            reembolso_persona = st.selectbox(
+                "Persona a reembolsar",
+                options=[""] + personas,
+                key="reembolso_persona",
+            )
+        else:
+            st.info(
+                "No hay personas registradas. Pide al administrador que agregue en Admin > Personas."
+            )
+            reembolso_persona = ""
+    else:
+        reembolso_persona = ""
+
+    if supplier_id and amount and amount > 0:
+        dupes = recent_similar_expenses(supplier_id, float(amount), days=30)
+        if dupes:
+            with st.expander("⚠️ Posibles duplicados (últimos 30 días)", expanded=True):
+                for d in dupes:
+                    url = signed_url_for_receipt(d.get("supporting_doc_key") or "", expires=300)
+                    st.markdown(
+                        f"- **{d['created_at']}** — {sup_name} — Monto: **{d['amount']:.2f}** — Estado: **{d['status']}**  "
+                        + (f"[Ver documento]({url})" if url else "")
+                    )
+        else:
+            st.caption("No se encontraron solicitudes similares recientes.")
+
+    disable_submit = (not suppliers) or (reembolso and not personas)
+
+    if st.button(
+        "Enviar solicitud",
+        type="primary",
+        use_container_width=False,
+        disabled=disable_submit,
+    ):
+        if not supplier_id:
+            st.error("Selecciona un proveedor.")
+        elif not amount or amount <= 0:
+            st.error("Ingresa un monto válido mayor a cero.")
+        elif not categoria:
+            st.error("Selecciona una categoría.")
+        elif not file:
+            st.error("Adjunta el documento de respaldo.")
+        elif reembolso and not reembolso_persona:
+            st.error("Selecciona la persona a reembolsar.")
+        else:
+            try:
+                sb = get_client()
+                bucket = "quotes"
+                file_id = uuid.uuid4().hex + Path(file.name).suffix
+
+                sb.storage.from_(bucket).upload(
+                    file_id,
+                    file.getvalue(),
+                    {"content-type": file.type},
+                )
+
+                expense_id = create_expense(
+                    requested_by=user_id,
+                    supplier_id=supplier_id,
+                    amount=float(Decimal(str(amount))),
+                    category=categoria,
+                    supporting_doc_key=file_id,
+                    description=descripcion.strip() if descripcion else None,
+                    reimbursement=reembolso,
+                    reimbursement_person=reembolso_persona or None,
+                )
+
+                if expense_id and (comentario_inicial or "").strip():
+                    add_expense_comment(expense_id, user_id, comentario_inicial.strip())
+
+                st.success("Solicitud creada correctamente.")
+                st.balloons()
+                st.session_state.reset_form = True
+                st.session_state.solicitudes_metrics_dirty = True
+                st.session_state.solicitudes_rows_all = None
+                st.rerun(scope="fragment")
+            except Exception as e:
+                st.error(f"No se pudo crear la solicitud: {e}")
+
+
+@st.fragment
+def solicitud_detalle_fragment():
+    st.write("**Detalles y actualización de una solicitud**")
+
+    if st.session_state.get("solic_detalle_reset"):
+        st.session_state.solic_detalle_comment = ""
+        st.session_state.solic_detalle_reset = False
+
+    mis = list_my_expenses(user_id, status=None)
+    if not mis:
+        st.caption("Aún no tienes solicitudes.")
+        st.stop()
+
+    opts = {
+        f"{m['created_at']} — {m['supplier_name']} — {m['amount']:.2f} — {m['status']}": m["id"]
+        for m in mis
+    }
+    sel_label = st.selectbox(
+        "Selecciona una solicitud",
+        [""] + list(opts.keys()),
+        index=0,
+        key="solic_detalle_sel",
+    )
+    if not sel_label:
+        st.stop()
+    sel_id = opts[sel_label]
+
+    exp = get_my_expense(user_id, sel_id)
+    if not exp:
+        st.error("No se encontró la solicitud seleccionada.")
+        st.stop()
+
+    detalles_md = (
+        f"**Proveedor:** {exp['supplier_name']}  \n"
+        f"**Monto:** {exp['amount']:.2f}  \n"
+        f"**Categoría:** {exp['category']}  \n"
+        f"**Descripción:** {exp.get('description','')}  \n"
+        f"**Estado:** {exp['status']}  \n"
+        f"**Fecha Creado:** {pd.to_datetime(exp['created_at']).strftime('%Y-%m-%d')}  \n"
+        f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
+    )
+    if exp.get("reimbursement"):
+        detalles_md += (
+            f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
+        )
+    st.markdown(detalles_md)
+
+    rec_key = exp.get("supporting_doc_key")
+    pay_key = exp.get("payment_doc_key")
+    rec_url = signed_url_for_receipt(rec_key, 600)
+    pay_url = signed_url_for_payment(pay_key, 600)
+    colf1, colf2 = st.columns(2)
+    with colf1:
+        st.link_button(
+            "Ver recibo",
+            rec_url or "#",
+            use_container_width=True,
+            disabled=not bool(rec_url),
+        )
+    with colf2:
+        st.link_button(
+            "Ver comprobante de pago",
+            pay_url or "#",
+            use_container_width=True,
+            disabled=not bool(pay_url),
+        )
+
+    st.divider()
+
+    st.write("**Agregar comentario**")
+    with st.form("form_comentario", clear_on_submit=True):
+        txt = st.text_area(
+            "Comentario",
+            placeholder="Escribe tu comentario…",
+            key="solic_detalle_comment",
+        )
+        if st.form_submit_button("Guardar comentario"):
+            if not txt or not txt.strip():
+                st.error("Escribe un comentario.")
+            else:
+                try:
+                    add_expense_comment(sel_id, user_id, txt.strip())
+                    st.success("Comentario agregado.")
+                    st.session_state.solic_detalle_reset = True
+                    st.session_state.solicitudes_metrics_dirty = True
+                    st.session_state.solicitudes_rows_all = None
+                    st.rerun(scope="fragment")
+                except Exception as e:
+                    st.error(f"No se pudo guardar el comentario: {e}")
+
+    def _fmt_dt(s: str) -> str:
+        try:
+            return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return s
+
+    st.write("**Comentarios**")
+    comentarios = list_expense_comments(sel_id)
+    if not comentarios:
+        st.caption("No hay comentarios.")
+    else:
+        com_df = pd.DataFrame(
+            [
+                {
+                    "Fecha": _fmt_dt(c["created_at"]),
+                    "Autor": c.get("actor_email", ""),
+                    "Comentario": c["message"],
+                }
+                for c in comentarios
+            ]
+        )
+        st.dataframe(com_df, use_container_width=True, hide_index=True)
+
+    st.divider()
+    st.write("**Historial de cambios**")
+    logs = list_expense_logs(sel_id)
+    if not logs:
+        st.caption("No hay historial.")
+    else:
+        log_df = pd.DataFrame(
+            [
+                {
+                    "Fecha": _fmt_dt(lg["created_at"]),
+                    "Actor": lg.get("actor_email", ""),
+                    "Mensaje": lg.get("message", ""),
+                }
+                for lg in logs
+            ]
+        )
+        st.dataframe(log_df, use_container_width=True, hide_index=True)
+
+
 # ==========================
 # Tab 1: Nueva solicitud
 # ==========================
 with tab_nueva:
-    with st.fragment("solicitud_nueva"):
-        st.write("**Crear nueva solicitud**")
-
-        # Reinicia los campos si se indicó
-        if st.session_state.get("reset_form"):
-            st.session_state.reset_form = False
-            st.session_state["sup_name"] = ""
-            st.session_state["monto"] = 0.0
-            st.session_state["descripcion"] = ""
-            st.session_state["comentario"] = ""
-            st.session_state.pop("archivo", None)
-            st.session_state["categoria"] = ""
-            st.session_state["reembolso"] = False
-            st.session_state["reembolso_persona"] = ""
-
-        # Estado inicial para widgets
-        if "sup_name" not in st.session_state:
-            st.session_state["sup_name"] = ""
-        if "monto" not in st.session_state:
-            st.session_state["monto"] = 0.0
-        if "descripcion" not in st.session_state:
-            st.session_state["descripcion"] = ""
-        if "comentario" not in st.session_state:
-            st.session_state["comentario"] = ""
-        if "categoria" not in st.session_state:
-            st.session_state["categoria"] = ""
-        if "reembolso" not in st.session_state:
-            st.session_state["reembolso"] = False
-        if "reembolso_persona" not in st.session_state:
-            st.session_state["reembolso_persona"] = ""
-
-        suppliers = list_suppliers()
-        if not suppliers:
-            st.info("Aún no hay proveedores. Pide a un administrador que cree al menos uno.")
-        sup_opts = {s["name"]: {"id": s["id"], "category": s.get("category") or ""} for s in suppliers}
-        sup_name = st.selectbox(
-            "Proveedor *", options=[""] + list(sup_opts.keys()), key="sup_name"
-        )
-        sel_sup = sup_opts.get(sup_name) if sup_name else None
-        supplier_id = sel_sup["id"] if sel_sup else None
-        categoria = sel_sup["category"] if sel_sup else ""
-
-        col_a, col_b = st.columns([1, 1])
-        with col_a:
-            amount = st.number_input(
-                "Monto *", min_value=0.00, step=0.01, format="%.2f", key="monto"
-            )
-        with col_b:
-            # Categoría fija, tomada del proveedor
-            st.session_state["categoria"] = categoria
-            st.selectbox(
-                "Categoría *",
-                options=[categoria] if categoria else [""],
-                key="categoria",
-                disabled=True,
-            )
-
-        descripcion = st.text_input(
-            "Descripción breve *",
-            placeholder="Ej. Suscripción anual de software...",
-            key="descripcion",
-        )
-
-        file = st.file_uploader(
-            "Documento de respaldo (recibo/factura) *",
-            type=["pdf", "png", "jpg", "jpeg", "webp"],
-            key="archivo",
-        )
-        comentario_inicial = st.text_area(
-            "Comentario (opcional)",
-            placeholder="Ej. Detalles útiles para aprobación…",
-            key="comentario",
-        )
-
-        reembolso = st.checkbox("Reembolso", key="reembolso")
-        personas = list_people() if reembolso else []
-        if reembolso:
-            if personas:
-                reembolso_persona = st.selectbox(
-                    "Persona a reembolsar",
-                    options=[""] + personas,
-                    key="reembolso_persona",
-                )
-            else:
-                st.info(
-                    "No hay personas registradas. Pide al administrador que agregue en Admin > Personas."
-                )
-                reembolso_persona = ""
-        else:
-            reembolso_persona = ""
-
-        # Duplicados simples: mismo proveedor y mismo monto en los últimos 30 días
-        if supplier_id and amount and amount > 0:
-            dupes = recent_similar_expenses(supplier_id, float(amount), days=30)
-            if dupes:
-                with st.expander("⚠️ Posibles duplicados (últimos 30 días)", expanded=True):
-                    for d in dupes:
-                        url = signed_url_for_receipt(d.get("supporting_doc_key") or "", expires=300)
-                        st.markdown(
-                            f"- **{d['created_at']}** — {sup_name} — Monto: **{d['amount']:.2f}** — Estado: **{d['status']}**  "
-                            + (f"[Ver documento]({url})" if url else "")
-                        )
-            else:
-                st.caption("No se encontraron solicitudes similares recientes.")
-
-        disable_submit = (not suppliers) or (reembolso and not personas)
-
-        # Enviar
-        if st.button(
-            "Enviar solicitud",
-            type="primary",
-            use_container_width=False,
-            disabled=disable_submit,
-        ):
-            if not supplier_id:
-                st.error("Selecciona un proveedor.")
-            elif not amount or amount <= 0:
-                st.error("Ingresa un monto válido mayor a cero.")
-            elif not categoria:
-                st.error("Selecciona una categoría.")
-            elif not file:
-                st.error("Adjunta el documento de respaldo.")
-            elif reembolso and not reembolso_persona:
-                st.error("Selecciona la persona a reembolsar.")
-            else:
-                try:
-                    # Subir archivo a Storage (bucket 'quotes')
-                    sb = get_client()
-                    bucket = "quotes"  # tu bucket
-                    file_id = uuid.uuid4().hex + Path(file.name).suffix
-
-                    sb.storage.from_(bucket).upload(
-                        file_id,
-                        file.getvalue(),
-                        {"content-type": file.type},
-                    )
-
-                    expense_id = create_expense(
-                        requested_by=user_id,
-                        supplier_id=supplier_id,
-                        amount=float(Decimal(str(amount))),
-                        category=categoria,
-                        supporting_doc_key=file_id,
-                        description=descripcion.strip() if descripcion else None,
-                        reimbursement=reembolso,
-                        reimbursement_person=reembolso_persona or None,
-                    )
-
-                    # Comentario inicial (si hay)
-                    if expense_id and (comentario_inicial or "").strip():
-                        add_expense_comment(expense_id, user_id, comentario_inicial.strip())
-
-                    st.success("Solicitud creada correctamente.")
-                    st.balloons()
-                    st.session_state.reset_form = True
-                    st.session_state.solicitudes_metrics_dirty = True
-                    st.session_state.solicitudes_rows_all = None
-                    st.rerun(fragment="solicitud_nueva")
-                except Exception as e:
-                    st.error(f"No se pudo crear la solicitud: {e}")
+    solicitud_nueva_fragment()
 
 # ==========================
 # Tab 2: Mis solicitudes
@@ -278,139 +410,4 @@ with tab_mias:
 # Tab 3: Detalles y actualizar
 # ==========================
 with tab_detalle:
-    with st.fragment("solicitud_detalle"):
-        st.write("**Detalles y actualización de una solicitud**")
-
-        if st.session_state.get("solic_detalle_reset"):
-            st.session_state.solic_detalle_comment = ""
-            st.session_state.solic_detalle_reset = False
-
-        mis = list_my_expenses(user_id, status=None)
-        if not mis:
-            st.caption("Aún no tienes solicitudes.")
-            st.stop()
-
-        # Selector de una solicitud
-        opts = {
-            f"{m['created_at']} — {m['supplier_name']} — {m['amount']:.2f} — {m['status']}": m["id"]
-            for m in mis
-        }
-        sel_label = st.selectbox(
-            "Selecciona una solicitud",
-            [""] + list(opts.keys()),
-            index=0,
-            key="solic_detalle_sel",
-        )
-        if not sel_label:
-            st.stop()
-        sel_id = opts[sel_label]
-
-        exp = get_my_expense(user_id, sel_id)
-        if not exp:
-            st.error("No se encontró la solicitud seleccionada.")
-            st.stop()
-
-        # Encabezado de detalles
-        detalles_md = (
-            f"**Proveedor:** {exp['supplier_name']}  \n"
-            f"**Monto:** {exp['amount']:.2f}  \n"
-            f"**Categoría:** {exp['category']}  \n"
-            f"**Descripción:** {exp.get('description','')}  \n"
-            f"**Estado:** {exp['status']}  \n"
-            f"**Fecha Creado:** {pd.to_datetime(exp['created_at']).strftime('%Y-%m-%d')}  \n"
-            f"**Reembolso:** {'Sí' if exp.get('reimbursement') else 'No'}"
-        )
-        if exp.get("reimbursement"):
-            detalles_md += (
-                f"  \n**Persona a reembolsar:** {exp.get('reimbursement_person') or '(no especificada)'}"
-            )
-        st.markdown(detalles_md)
-
-        # Enlaces rápidos a archivos
-        rec_key = exp.get("supporting_doc_key")
-        pay_key = exp.get("payment_doc_key")
-        rec_url = signed_url_for_receipt(rec_key, 600)
-        pay_url = signed_url_for_payment(pay_key, 600)
-        colf1, colf2 = st.columns(2)
-        with colf1:
-            st.link_button(
-                "Ver recibo",
-                rec_url or "#",
-                use_container_width=True,
-                disabled=not bool(rec_url),
-            )
-        with colf2:
-            st.link_button(
-                "Ver comprobante de pago",
-                pay_url or "#",
-                use_container_width=True,
-                disabled=not bool(pay_url),
-            )
-
-        st.divider()
-
-        # Agregar comentario
-        st.write("**Agregar comentario**")
-        with st.form("form_comentario", clear_on_submit=True):
-            txt = st.text_area(
-                "Comentario",
-                placeholder="Escribe tu comentario…",
-                key="solic_detalle_comment",
-            )
-            if st.form_submit_button("Guardar comentario"):
-                if not txt or not txt.strip():
-                    st.error("Escribe un comentario.")
-                else:
-                    try:
-                        add_expense_comment(sel_id, user_id, txt.strip())
-                        st.success("Comentario agregado.")
-                        st.session_state.solic_detalle_reset = True
-                        st.session_state.solicitudes_metrics_dirty = True
-                        st.session_state.solicitudes_rows_all = None
-                        st.rerun(fragment="solicitud_detalle")
-                    except Exception as e:
-                        st.error(f"No se pudo guardar el comentario: {e}")
-
-        def _fmt_dt(s: str) -> str:
-            try:
-                return pd.to_datetime(s).strftime("%Y-%m-%d %H:%M")
-            except Exception:
-                return s
-
-        # Comentarios (solo los de tipo 'comment')
-        st.write("**Comentarios**")
-        comentarios = list_expense_comments(sel_id)
-        if not comentarios:
-            st.caption("No hay comentarios.")
-        else:
-            com_df = pd.DataFrame(
-                [
-                    {
-                        "Fecha": _fmt_dt(c["created_at"]),
-                        "Autor": c.get("actor_email", ""),
-                        "Comentario": c["message"],
-                    }
-                    for c in comentarios
-                ]
-            )
-            st.dataframe(com_df, use_container_width=True, hide_index=True)
-
-        st.divider()
-
-        # Historial completo (logs)
-        st.write("**Historial de cambios**")
-        logs = list_expense_logs(sel_id)
-        if not logs:
-            st.caption("No hay historial.")
-        else:
-            log_df = pd.DataFrame(
-                [
-                    {
-                        "Fecha": _fmt_dt(lg["created_at"]),
-                        "Actor": lg.get("actor_email", ""),
-                        "Mensaje": lg.get("message", ""),
-                    }
-                    for lg in logs
-                ]
-            )
-            st.dataframe(log_df, use_container_width=True, hide_index=True)
+    solicitud_detalle_fragment()


### PR DESCRIPTION
## Summary
- migrate all pages using `with st.fragment(...)` to the Streamlit 1.49 decorator form
- ensure fragment reruns use `st.rerun(scope="fragment")` and keep session state refresh logic intact
- refactor admin, aprobador, pagador and solicitante pages to render via fragment functions while preserving existing behaviours

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cb378d43dc832ea7a777cb8bf07d28