### PR TITLE
Implement role-based top navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,3 @@
-from typing import Optional, Set
-
 import streamlit as st
 from f_auth import (
     login,
@@ -7,14 +5,6 @@ from f_auth import (
     sign_out,
     current_user_roles,
 )
-
-ROLE_PAGE_MAP = {
-    "administrador": "pages/administrador.py",
-    "solicitante": "pages/solicitante.py",
-    "aprobador": "pages/aprobador.py",
-    "pagador": "pages/pagador.py",
-    "lector": "pages/lector.py",
-}
 
 ROLE_LABELS = {
     "administrador": "Administración",
@@ -32,16 +22,30 @@ ROLE_PRIORITY = [
     "lector",
 ]
 
-
-def _first_page_for_roles(roles: Set[str]) -> Optional[str]:
-    for role in ROLE_PRIORITY:
-        if role in roles:
-            return ROLE_PAGE_MAP[role]
-    return None
+ROLE_PAGE_CONFIG = {
+    "administrador": {
+        "path": "pages/administrador.py",
+        "icon": "🛡️",
+    },
+    "solicitante": {
+        "path": "pages/solicitante.py",
+        "icon": "🧾",
+    },
+    "aprobador": {
+        "path": "pages/aprobador.py",
+        "icon": "✅",
+    },
+    "pagador": {
+        "path": "pages/pagador.py",
+        "icon": "💸",
+    },
+    "lector": {
+        "path": "pages/lector.py",
+        "icon": "📊",
+    },
+}
 
 st.set_page_config(page_icon="📧", layout="centered")
-
-st.write("**Pagos • Iniciar sesión**")
 
 user = current_user()
 if user:
@@ -58,12 +62,29 @@ if user:
         )
         st.stop()
 
-    st.success("¡Listo! Ya estás autenticado.")
-    st.write("Selecciona una sección para continuar:")
+    available_pages = []
     for role in ROLE_PRIORITY:
-        if role in roles:
-            st.page_link(ROLE_PAGE_MAP[role], label=f"{ROLE_LABELS[role]}")
+        if role not in roles:
+            continue
+        config = ROLE_PAGE_CONFIG[role]
+        available_pages.append(
+            st.Page(
+                config["path"],
+                title=ROLE_LABELS[role],
+                icon=config.get("icon") or "",
+                default=len(available_pages) == 0,
+            )
+        )
+
+    if not available_pages:
+        st.error("No se encontró una página asignada para tus roles.")
+        st.stop()
+
+    pg = st.navigation(available_pages, position="top")
+    pg.run()
     st.stop()
+
+st.write("**Pagos • Iniciar sesión**")
 
 with st.form("login_form", clear_on_submit=False):
     email = st.text_input("Email", placeholder="tu@empresa.com")
@@ -79,10 +100,6 @@ with st.form("login_form", clear_on_submit=False):
                 )
                 st.stop()
 
-            target = _first_page_for_roles(roles)
-            if target:
-                st.switch_page(target)
-            else:
-                st.error("No se encontró una página asignada para tus roles.")
+            st.rerun()
         else:
             st.error("Wrong credentials")

--- a/pages/administrador.py
+++ b/pages/administrador.py
@@ -18,7 +18,6 @@ from f_cud import (
     create_person,
 )
 
-st.set_page_config(page_icon="🛡️", layout="wide")
 require_administrador()
 
 st.write("**Administración**")

--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -22,8 +22,6 @@ from f_read import (
 from f_cud import update_expense_status, add_expense_comment
 
 
-
-st.set_page_config(page_title="Aprobador", page_icon="✅", layout="wide")
 require_aprobador()
 
 me = current_user()

--- a/pages/lector.py
+++ b/pages/lector.py
@@ -17,7 +17,6 @@ from f_read import (
     _render_download,
 )
 
-st.set_page_config(page_title="Lector", page_icon="📊", layout="wide")
 require_lector()
 
 me = current_user()

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -28,7 +28,6 @@ from f_read import (
 
 from f_cud import mark_expense_as_paid, add_expense_comment, update_expense_status
 
-st.set_page_config(page_title="Pagador", page_icon="💸", layout="wide")
 require_pagador()
 
 me = current_user()

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -22,7 +22,6 @@ from f_read import (
 from f_cud import create_expense, add_expense_comment
 
 # ===== Config =====
-st.set_page_config(page_title="Solicitudes", page_icon="🧾", layout="wide")
 require_solicitante()
 
 st.write("**Solicitudes**")


### PR DESCRIPTION
## Summary
- replace the manual role router with Streamlit's `st.navigation`, building top navigation links from each signed-in user's roles
- trigger a rerun after login and hide navigation until authentication succeeds so only authorized pages appear
- drop per-page `st.set_page_config` calls so page metadata comes from the router configuration

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cb424d0ed0832ea823e010a330a144