### PR TITLE
Implement role-based top navigation

### DIFF
--- a/pages/administrador.py
+++ b/pages/administrador.py
@@ -18,7 +18,6 @@ from f_cud import (
     create_person,
 )
 
-st.set_page_config(page_icon="🛡️", layout="wide")
 require_administrador()
 
 st.write("**Administración**")

--- a/pages/aprobador.py
+++ b/pages/aprobador.py
@@ -22,8 +22,6 @@ from f_read import (
 from f_cud import update_expense_status, add_expense_comment
 
 
-
-st.set_page_config(page_title="Aprobador", page_icon="✅", layout="wide")
 require_aprobador()
 
 me = current_user()

--- a/pages/lector.py
+++ b/pages/lector.py
@@ -17,7 +17,6 @@ from f_read import (
     _render_download,
 )
 
-st.set_page_config(page_title="Lector", page_icon="📊", layout="wide")
 require_lector()
 
 me = current_user()

--- a/pages/pagador.py
+++ b/pages/pagador.py
@@ -28,7 +28,6 @@ from f_read import (
 
 from f_cud import mark_expense_as_paid, add_expense_comment, update_expense_status
 
-st.set_page_config(page_title="Pagador", page_icon="💸", layout="wide")
 require_pagador()
 
 me = current_user()

--- a/pages/solicitante.py
+++ b/pages/solicitante.py
@@ -22,7 +22,6 @@ from f_read import (
 from f_cud import create_expense, add_expense_comment
 
 # ===== Config =====
-st.set_page_config(page_title="Solicitudes", page_icon="🧾", layout="wide")
 require_solicitante()
 
 st.write("**Solicitudes**")


### PR DESCRIPTION
## Summary
- replace the manual role router with Streamlit's `st.navigation`, building top navigation links from each signed-in user's roles
- funnel both login and authenticated views through `st.navigation`, keeping the sidebar clear before sign-in and surfacing warnings via router pages with wide layout
- drop per-page `st.set_page_config` calls so page metadata comes from the router configuration

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cb424d0ed0832ea823e010a330a144