### PR TITLE
Remove report tab from lector view

### DIFF
--- a/lector.py
+++ b/lector.py
@@ -117,131 +117,80 @@ if df.empty:
     st.stop()
 
 # --------------------------
-# Tabs: Reporte y Detalle
+# Tabla y detalle de gastos
 # --------------------------
-tab_reporte, tab_detalle = st.tabs(["Reporte", "Detalle"])
+st.write("**Gastos filtrados**")
 
-# === Tab Reporte ===
-with tab_reporte:
-    m1, m2, m3, m4 = st.columns(4)
-    m1.metric("Gastos (conteo)", f"{len(df):,}")
-    m2.metric("Monto total", f"{df['amount'].sum():,.2f}")
-    m3.metric("Monto promedio", f"{df['amount'].mean():,.2f}")
-    m4.metric("Monto mediano", f"{df['amount'].median():,.2f}")
+# Tabla con columnas claves
+show_df = df.copy()
+show_df["Creado"] = show_df["created_at"].map(_fmt_dt)
+show_df["Pagado"] = show_df["paid_at"].map(_fmt_dt)
+show_df["Documento de respaldo"] = show_df["supporting_doc_key"].map(
+    lambda k: signed_url_for_receipt(k.strip()) if isinstance(k, str) and k.strip() else None
+)
+show_df["Comprobante de pago"] = show_df["payment_doc_key"].map(
+    lambda k: signed_url_for_payment(k.strip()) if isinstance(k, str) and k.strip() else None
+)
+show_df = show_df[[
+    "supplier_name", "description", "amount", "category",
+    "requested_by_email", "approved_by_email", "paid_by_email",
+    "Creado", "Pagado", "Documento de respaldo", "Comprobante de pago"
+]].rename(columns={
+    "supplier_name": "Proveedor",
+    "description": "Descripción",
+    "amount": "Monto",
+    "category": "Categoría",
+    "requested_by_email": "Solicitante",
+    "approved_by_email": "Aprobador",
+    "paid_by_email": "Pagador",
+})
 
-    st.divider()
+st.dataframe(
+    show_df,
+    use_container_width=True,
+    hide_index=True,
+    column_config={
+        "Documento de respaldo": st.column_config.LinkColumn(
+            "Documento de respaldo",
+            help="Abrir el documento de respaldo",
+            display_text="Abrir",
+        ),
+        "Comprobante de pago": st.column_config.LinkColumn(
+            "Comprobante de pago",
+            help="Abrir el comprobante de pago",
+            display_text="Abrir",
+        ),
+    },
+)
 
-    st.write("**Comparar por dimensión**")
+# Selector de un gasto
+opt_map = {
+    f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['paid_at'])} — {r.get('requested_by_email','')}"
+    : r["id"]
+    for _, r in df.iterrows()
+}
+sel_label = st.selectbox("Selecciona un gasto para ver detalles", list(opt_map.keys()))
+eid = opt_map[sel_label]
 
-    dim = st.radio(
-        "Dimensión",
-        options=["Proveedores", "Solicitantes", "Aprobadores", "Categorías"],
-        horizontal=True,
-    )
-    metric = st.radio(
-        "Métrica",
-        options=["Monto total", "Número de gastos"],
-        horizontal=True,
-    )
-    top_n = st.slider("Top N", min_value=5, max_value=50, value=10)
+# Mostrar detalle con documentos y previsualización
+row = df[df["id"] == eid].iloc[0]
+st.markdown(
+    f"**Proveedor:** {row['supplier_name']}  \n"
+    f"**Descripción:** {row.get('description','')}  \n"
+    f"**Monto:** {row['amount']:.2f}  \n"
+    f"**Categoría:** {row['category']}  \n"
+    f"**Solicitante:** {row.get('requested_by_email','')}  \n"
+    f"**Aprobador:** {row.get('approved_by_email','')}  \n"
+    f"**Pagador:** {row.get('paid_by_email','')}  \n"
+    f"**Creado:** {_fmt_dt(row['created_at'])}  \n"
+    f"**Pagado:** {_fmt_dt(row['paid_at'])}"
+)
 
-    if dim == "Proveedores":
-        field = "supplier_name"
-    elif dim == "Solicitantes":
-        field = "requested_by_email"
-    elif dim == "Aprobadores":
-        field = "approved_by_email"
-    else:
-        field = "category"
-
-    if metric == "Monto total":
-        ser = df.groupby(field)["amount"].sum()
-    else:
-        ser = df.groupby(field)["id"].count()
-
-    ser = ser.sort_values(ascending=False).head(top_n)
-
-    st.bar_chart(ser, use_container_width=True)
-    st.dataframe(
-        ser.rename(metric),
-        use_container_width=True,
-        height=400,
-    )
-
-# === Tab Detalle: tabla y detalle de un gasto ===
-with tab_detalle:
-    st.write("**Gastos filtrados**")
-
-    # Tabla con columnas claves
-    show_df = df.copy()
-    show_df["Creado"] = show_df["created_at"].map(_fmt_dt)
-    show_df["Pagado"] = show_df["paid_at"].map(_fmt_dt)
-    show_df["Documento de respaldo"] = show_df["supporting_doc_key"].map(
-        lambda k: signed_url_for_receipt(k.strip()) if isinstance(k, str) and k.strip() else None
-    )
-    show_df["Comprobante de pago"] = show_df["payment_doc_key"].map(
-        lambda k: signed_url_for_payment(k.strip()) if isinstance(k, str) and k.strip() else None
-    )
-    show_df = show_df[[
-        "supplier_name", "description", "amount", "category",
-        "requested_by_email", "approved_by_email", "paid_by_email",
-        "Creado", "Pagado", "Documento de respaldo", "Comprobante de pago"
-    ]].rename(columns={
-        "supplier_name": "Proveedor",
-        "description": "Descripción",
-        "amount": "Monto",
-        "category": "Categoría",
-        "requested_by_email": "Solicitante",
-        "approved_by_email": "Aprobador",
-        "paid_by_email": "Pagador",
-    })
-
-    st.dataframe(
-        show_df,
-        use_container_width=True,
-        hide_index=True,
-        column_config={
-            "Documento de respaldo": st.column_config.LinkColumn(
-                "Documento de respaldo",
-                help="Abrir el documento de respaldo",
-                display_text="Abrir",
-            ),
-            "Comprobante de pago": st.column_config.LinkColumn(
-                "Comprobante de pago",
-                help="Abrir el comprobante de pago",
-                display_text="Abrir",
-            ),
-        },
-    )
-
-    # Selector de un gasto
-    opt_map = {
-        f"{r['supplier_name']} — {r.get('description','')} — {_fmt_dt(r['paid_at'])} — {r.get('requested_by_email','')}"
-        : r["id"]
-        for _, r in df.iterrows()
-    }
-    sel_label = st.selectbox("Selecciona un gasto para ver detalles", list(opt_map.keys()))
-    eid = opt_map[sel_label]
-
-    # Mostrar detalle con documentos y previsualización
-    row = df[df["id"] == eid].iloc[0]
-    st.markdown(
-        f"**Proveedor:** {row['supplier_name']}  \n"
-        f"**Descripción:** {row.get('description','')}  \n"
-        f"**Monto:** {row['amount']:.2f}  \n"
-        f"**Categoría:** {row['category']}  \n"
-        f"**Solicitante:** {row.get('requested_by_email','')}  \n"
-        f"**Aprobador:** {row.get('approved_by_email','')}  \n"
-        f"**Pagador:** {row.get('paid_by_email','')}  \n"
-        f"**Creado:** {_fmt_dt(row['created_at'])}  \n"
-        f"**Pagado:** {_fmt_dt(row['paid_at'])}"
-    )
-
-    st.divider()
-    rec_key = row.get("supporting_doc_key")
-    pay_key = row.get("payment_doc_key")
-    cols_files = st.columns(2)
-    with cols_files[0]:
-        _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
-    with cols_files[1]:
-        _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)
+st.divider()
+rec_key = row.get("supporting_doc_key")
+pay_key = row.get("payment_doc_key")
+cols_files = st.columns(2)
+with cols_files[0]:
+    _render_download(rec_key, "Documento de respaldo", signed_url_for_receipt)
+with cols_files[1]:
+    _render_download(pay_key, "Comprobante de pago", signed_url_for_payment)


### PR DESCRIPTION
## Summary
- remove the Reporte tab from the lector dashboard
- keep the detail table and record drilldown visible without tabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b97a91f4832e98ad3c0a6622e8a9